### PR TITLE
* Changed `ParseTextProto`, `ParseTextProtoOrDie` to only work for actual derived proto types.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -21,18 +21,20 @@ BreakBeforeBinaryOperators: NonAssignment
 BreakBeforeConceptDeclarations: Always
 BreakBeforeTernaryOperators: true
 BreakInheritanceList: BeforeComma
+DerivePointerAlignment: false
 EmptyLineBeforeAccessModifier: Always
 FixNamespaceComments: true
 IndentRequiresClause: false
 InsertBraces: true
 InsertNewlineAtEOF: true
-# InsertTrailingCommas: true <- Would change structs to never bin pack
+## InsertTrailingCommas: true <- Would change structs to never bin pack
 IntegerLiteralSeparator:
   Binary: 0
   Decimal: 3
 KeepEmptyLinesAtTheStartOfBlocks: false
 MaxEmptyLinesToKeep: 1
 PackConstructorInitializers: NextLine
+PenaltyReturnTypeOnItsOwnLine: 1000
 PointerAlignment: Left
 QualifierAlignment: Left
 ReferenceAlignment: Left

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 /compile_commands.json
 # Ignore the directory in which `clangd` stores its local index.
 /.cache/
+/.vscode/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,13 @@
+repos:
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v2.3.0
+  hooks:
+  - id: check-merge-conflict
+  - id: check-yaml
+  - id: end-of-file-fixer
+  - id: trailing-whitespace
+
+- repo: https://github.com/pre-commit/mirrors-clang-format
+  rev: v16.0.4
+  hooks:
+  - id: clang-format

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,3 +1,30 @@
+# Copyright 2024 M.Boerger
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@hedron_compile_commands//:refresh_compile_commands.bzl", "refresh_compile_commands")
+
 package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])
+
+COM_GOOGLE_PROTOBUF="bazel-out/../../../external/com_google_protobuf/src"
+
+refresh_compile_commands(
+    name = "refresh_all",
+    targets = {
+        "//...": " ".join([
+          "--cxxopt=-I" + COM_GOOGLE_PROTOBUF,
+        ])
+    },
+)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# 0.4
+
+* Changed `ParseTextProto`, `ParseTextProtoOrDie` to only work for actual derived proto types.
+* Added `ParseProto` which returns `absl::StatusOr<MessageType>`.
+* Updated external dependencies.
+
+# 0.3
+
+* Added missing dependency.
+
+# 0.2
+
+* Small fixes, mostly to support a few older abseil/re2 versions.
+
+# 0.1
+
+* Initial release

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -18,6 +18,10 @@ load(":workspace.bzl", "workspace_load_modules")
 
 workspace_load_modules()
 
+load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
+
+bazel_skylib_workspace()
+
 load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
 
 protobuf_deps()

--- a/mbo/proto/BUILD.bazel
+++ b/mbo/proto/BUILD.bazel
@@ -54,6 +54,7 @@ cc_library(
         "@com_google_absl//absl/log:absl_check",
         "@com_google_absl//absl/log:absl_log",
         "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings:str_format",
         "@com_google_absl//absl/strings",
         "@com_google_protobuf//:protobuf",

--- a/mbo/proto/parse_text_proto_test.cc
+++ b/mbo/proto/parse_text_proto_test.cc
@@ -27,19 +27,32 @@ using ::mbo::proto::tests::SimpleMessage;
 
 class ParseTextProtoTest : public ::testing::Test {};
 
-TEST_F(ParseTextProtoTest, ParseOk) {
+TEST_F(ParseTextProtoTest, ParseTextOrDiePass) {
   EXPECT_THAT(ParseTextOrDie<SimpleMessage>(""), EqualsProto(""));
   EXPECT_THAT(ParseTextOrDie<SimpleMessage>("one: 42"), EqualsProto("one: 42"));
-  EXPECT_THAT((SimpleMessage)ParseTextProtoOrDie("one: 25"), EqualsProto("one: 25"));
 }
 
-TEST_F(ParseTextProtoTest, ParseError) {
+TEST_F(ParseTextProtoTest, ParseTextOrDieFail) {
   EXPECT_DEATH(
       ParseTextOrDie<SimpleMessage>("!!!"),
       // Using [0-9] in lieu of \\d to be compatible in open source.
       ".*Check failed:.*\n*"
       "File: '.*/parse_text_proto.*', Line: [0-9]+.*"
       "ParseTextOrDie<SimpleMessage>.*"
+      "INVALID_ARGUMENT: Line 0, Col 0: Expected identifier, got: !");
+}
+
+TEST_F(ParseTextProtoTest, ParseTextProtoOrDiePass) {
+  EXPECT_THAT((SimpleMessage)ParseTextProtoOrDie("one: 25"), EqualsProto("one: 25"));
+}
+
+TEST_F(ParseTextProtoTest, ParseTextProtoOrDieFail) {
+  EXPECT_DEATH(
+      SimpleMessage msg = ParseTextProtoOrDie("!!!"),
+      // Using [0-9] in lieu of \\d to be compatible in open source.
+      ".*Check failed:.*\n*"
+      "File: '.*/parse_text_proto.*', Line: [0-9]+.*"
+      "ParseTextProtoOrDie<SimpleMessage>.*"
       "INVALID_ARGUMENT: Line 0, Col 0: Expected identifier, got: !");
 }
 


### PR DESCRIPTION
* Added `ParseText` which returns `absl::StatusOr<MessageType>`.
* Changed `ParseTextProto`, `ParseTextProtoOrDie` to only work for actual derived proto types.