### PR TITLE
Fix/prepare_matchers_for_protobuf_28

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -37,3 +37,11 @@ build:asan --build_tag_filters=-no_san  # skip san targets
 build:asan --test_tag_filters=-no_san  # skip san targets
 build:asan --define san=true  # skip san targets
 build:asan --features=asan  # https://github.com/bazelbuild/bazel/issues/6932
+
+build --noincompatible_enable_cc_toolchain_resolution
+
+build:clang --incompatible_enable_cc_toolchain_resolution
+build:clang --cxxopt=-gmlt
+build:clang --host_cxxopt=-gmlt
+build:clang --linkopt=-fuse-ld=lld
+build:clang --host_linkopt=-fuse-ld=lld

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,26 +1,59 @@
 name: Test
 on: [push]
 jobs:
-  test:
+  test-clang-asan:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
+
+      - name: Setup Bazelisk
+        uses: bazelbuild/setup-bazelisk@v3
 
       - name: Bazel cache
-        id: bazel-cache
-        uses: actions/cache@v2
-        env:
-          version: 4.2.1
+        uses: actions/cache@v4
         with:
-          path: |
-            ~/.cache/bazel
-          key: ${{ runner.os }}-{{ env.version }}-bazel-cache
+            path: "~/.cache/bazel"
+            key: bazel-cache-clang-asan
 
-      - name: Test ASAN
+      - name: Test Clang/ASAN
         run: |
-          bazel test --config=asan -c dbg //...
+          bazel test --config=clang --config=asan -c dbg //...
 
-      - name: Test OPT
+  test-clang-opt:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bazelisk
+        uses: bazelbuild/setup-bazelisk@v3
+
+      - name: Bazel cache
+        uses: actions/cache@v4
+        with:
+            path: "~/.cache/bazel"
+            key: bazel-cache-clang-opt
+
+      - name: Test Clang/OPT
         run: |
-          bazel test -c opt //...
+          bazel test --config=clang -c opt //...
+
+  test-gcc-fastbuild:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bazelisk
+        uses: bazelbuild/setup-bazelisk@v3
+
+      - name: Bazel cache
+        uses: actions/cache@v4
+        with:
+            path: "~/.cache/bazel"
+            key: bazel-cache-gcc-fastbuild
+
+      - name: Test GCC/Fastbuild
+        run: |
+          CC=gcc bazel test -c fastbuild //...

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,15 @@
 # 0.5
 
-* Added support for com_google_protobuf >= Protocol Buffers v28.
+* Added support for com_google_protobuf >= Protocol Buffers v26.
 * Moved `ParseTextProtoHelper` into namespace `mbo::proto::proto_internal`.
 * Changed `ParseTextProtoHelper` to only accept derived proto messages on operator access.
 * Changed `ParseTextProtoHelper` to die on parsing failure.
 * Added `ParseText<T>() -> absl::StatusOr<T>`.
 * Improved error message detail for all parsing functions.
+* Updated all dependencies.
+* Verified protobuf versions 25.2, 26.0, 26.1, 27.0, 27.1, 27.2, 28.0-rc1.
+* Added Clang support.
+* Updated GH actions.
 
 # 0.4
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -18,10 +18,67 @@ load(":workspace.bzl", "workspace_load_modules")
 
 workspace_load_modules()
 
+###########################################################################
+
 load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
 
 bazel_skylib_workspace()
 
+###########################################################################
+
 load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
 
 protobuf_deps()
+
+###########################################################################
+
+load("@rules_foreign_cc//foreign_cc:repositories.bzl", "rules_foreign_cc_dependencies")
+
+rules_foreign_cc_dependencies()
+
+###########################################################################
+
+load("@toolchains_llvm//toolchain:deps.bzl", "bazel_toolchain_dependencies")
+
+bazel_toolchain_dependencies()
+
+load("@toolchains_llvm//toolchain:rules.bzl", "llvm_toolchain")
+
+llvm_toolchain(
+    name = "llvm_toolchain",
+    llvm_versions = {
+        "linux-aarch64": "17.0.6",
+        "linux-x86_64": "17.0.6",
+        "darwin-aarch64": "17.0.6",
+        "darwin-x86_64": "15.0.7",  # For Intel based macs.
+    },
+    sha256 = {
+        "linux-aarch64": "6dd62762285326f223f40b8e4f2864b5c372de3f7de0731cb7cd55ca5287b75a",
+        "linux-x86_64": "884ee67d647d77e58740c1e645649e29ae9e8a6fe87c1376be0f3a30f3cc9ab3",
+        "darwin-aarch64": "1264eb3c2a4a6d5e9354c3e5dc5cb6c6481e678f6456f36d2e0e566e9400fcad",
+        "darwin-x86_64": "d16b6d536364c5bec6583d12dd7e6cf841b9f508c4430d9ee886726bd9983f1c",
+    },
+    strip_prefix = {
+        "linux-aarch64": "clang+llvm-17.0.6-aarch64-linux-gnu",
+        "linux-x86_64": "clang+llvm-17.0.6-x86_64-linux-gnu-ubuntu-22.04",
+        "darwin-aarch64": "clang+llvm-17.0.6-arm64-apple-darwin22.0",
+        "darwin-x86_64": "clang+llvm-15.0.7-x86_64-apple-darwin21.0",
+    },
+    urls = {
+        "linux-aarch64": ["https://github.com/llvm/llvm-project/releases/download/llvmorg-17.0.6/clang+llvm-17.0.6-aarch64-linux-gnu.tar.xz"],
+        "linux-x86_64": ["https://github.com/llvm/llvm-project/releases/download/llvmorg-17.0.6/clang+llvm-17.0.6-x86_64-linux-gnu-ubuntu-22.04.tar.xz"],
+        "darwin-aarch64": ["https://github.com/llvm/llvm-project/releases/download/llvmorg-17.0.6/clang+llvm-17.0.6-arm64-apple-darwin22.0.tar.xz"],
+        "darwin-x86_64": ["https://github.com/llvm/llvm-project/releases/download/llvmorg-15.0.7/clang+llvm-15.0.7-x86_64-apple-darwin21.0.tar.xz"],
+    },
+)
+
+load("@llvm_toolchain//:toolchains.bzl", "llvm_register_toolchains")
+
+llvm_register_toolchains()
+
+###########################################################################
+
+# Run: ./compile_commands-update.sh
+load("@hedron_compile_commands//:workspace_setup.bzl", "hedron_compile_commands_setup")
+
+hedron_compile_commands_setup()

--- a/mbo/proto/matchers.cc
+++ b/mbo/proto/matchers.cc
@@ -44,14 +44,20 @@ public:
   StringErrorCollector(StringErrorCollector&&) = delete;
   StringErrorCollector &operator=(StringErrorCollector&&) = delete;
 
-  void AddError(int line, int column, const std::string &message) override {
-    absl::SubstituteAndAppend(error_text_, "$0($1): $2\n", line, column,
-                              message);
+#if GOOGLE_PROTOBUF_VERSION >= 5028000
+  void RecordError(int line, int column, std::string_view message) override {
+#else
+  void AddError(int line, int column, const std::string& message) override {
+#endif
+    absl::SubstituteAndAppend(error_text_, "$0($1): $2\n", line, column, message);
   }
 
-  void AddWarning(int line, int column, const std::string &message) override {
-    absl::SubstituteAndAppend(error_text_, "$0($1): $2\n", line, column,
-                              message);
+#if GOOGLE_PROTOBUF_VERSION >= 5028000
+  void RecordWarning(int line, int column, std::string_view message) override {
+#else
+  void AddWarning(int line, int column, const std::string& message) override {
+#endif
+    absl::SubstituteAndAppend(error_text_, "$0($1): $2\n", line, column, message);
   }
 
 private:

--- a/mbo/proto/matchers.cc
+++ b/mbo/proto/matchers.cc
@@ -44,7 +44,7 @@ public:
   StringErrorCollector(StringErrorCollector&&) = delete;
   StringErrorCollector &operator=(StringErrorCollector&&) = delete;
 
-#if GOOGLE_PROTOBUF_VERSION >= 5028000
+#if GOOGLE_PROTOBUF_VERSION >= 5026000
   void RecordError(int line, int column, std::string_view message) override {
 #else
   void AddError(int line, int column, const std::string& message) override {
@@ -52,7 +52,7 @@ public:
     absl::SubstituteAndAppend(error_text_, "$0($1): $2\n", line, column, message);
   }
 
-#if GOOGLE_PROTOBUF_VERSION >= 5028000
+#if GOOGLE_PROTOBUF_VERSION >= 5026000
   void RecordWarning(int line, int column, std::string_view message) override {
 #else
   void AddWarning(int line, int column, const std::string& message) override {

--- a/mbo/proto/parse_text_proto.cc
+++ b/mbo/proto/parse_text_proto.cc
@@ -39,7 +39,7 @@ class SilentErrorCollector : public google::protobuf::io::ErrorCollector {
     absl::LogSeverity severity = absl::LogSeverity::kError;
   };
 
-#if GOOGLE_PROTOBUF_VERSION >= 5028000
+#if GOOGLE_PROTOBUF_VERSION >= 5026000
   void RecordError(int line, int column, std::string_view message) override {
 #else
   void AddError(int line, int column, const std::string& message) override {
@@ -50,7 +50,7 @@ class SilentErrorCollector : public google::protobuf::io::ErrorCollector {
     .severity = absl::LogSeverity::kError});
   }
 
-#if GOOGLE_PROTOBUF_VERSION >= 5028000
+#if GOOGLE_PROTOBUF_VERSION >= 5026000
   void RecordWarning(int line, int column, std::string_view message) override {
 #else
   void AddWarning(int line, int column, const std::string& message) override {

--- a/workspace.bzl
+++ b/workspace.bzl
@@ -20,44 +20,42 @@ load("//bzl:archive.bzl", "github_archive", "http_archive")
 def workspace_load_modules():
     """Loads all modules requred by the workspace."""
 
-    # https://github.com/bazelbuild/platforms/releases
+    # https://github.com/bazelbuild/platforms
     http_archive(
         name = "platforms",
         urls = [
-            "https://mirror.bazel.build/github.com/bazelbuild/platforms/releases/download/0.0.8/platforms-0.0.8.tar.gz",
-            "https://github.com/bazelbuild/platforms/releases/download/0.0.8/platforms-0.0.8.tar.gz",
+            "https://github.com/bazelbuild/platforms/releases/download/0.0.10/platforms-0.0.10.tar.gz",
+            "https://mirror.bazel.build/github.com/bazelbuild/platforms/releases/download/0.0.10/platforms-0.0.10.tar.gz",
         ],
-        sha256 = "8150406605389ececb6da07cbcb509d5637a3ab9a24bc69b1101531367d89d74",
+        sha256 = "218efe8ee736d26a3572663b374a253c012b716d8af0c07e842e82f238a0a7ee",
     )
 
-    # https://github.com/bazelbuild/rules_license/releases
+    # https://github.com/bazelbuild/rules_license
     http_archive(
         name = "rules_license",
         urls = [
-            "https://mirror.bazel.build/github.com/bazelbuild/rules_license/releases/download/0.0.7/rules_license-0.0.7.tar.gz",
-            "https://github.com/bazelbuild/rules_license/releases/download/0.0.7/rules_license-0.0.7.tar.gz",
+            "https://github.com/bazelbuild/rules_license/releases/download/0.0.8/rules_license-0.0.8.tar.gz",
+            "https://mirror.bazel.build/github.com/bazelbuild/rules_license/releases/download/0.0.8/rules_license-0.0.8.tar.gz",
         ],
-        sha256 = "4531deccb913639c30e5c7512a054d5d875698daeb75d8cf90f284375fe7c360",
+        sha256 = "241b06f3097fd186ff468832150d6cc142247dc42a32aaefb56d0099895fd229",
     )
 
-    # https://github.com/bazelbuild/bazel-skylib/releases
+    # https://github.com/bazelbuild/bazel-skylib
     http_archive(
         name = "bazel_skylib",
-        sha256 = "cd55a062e763b9349921f0f5db8c3933288dc8ba4f76dd9416aac68acee3cb94",
+        sha256 = "bc283cdfcd526a52c3201279cda4bc298652efa898b10b4db0837dc51652756f",
         urls = [
-            "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.5.0/bazel-skylib-1.5.0.tar.gz",
-            "https://github.com/bazelbuild/bazel-skylib/releases/download/1.5.0/bazel-skylib-1.5.0.tar.gz",
+            "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.7.1/bazel-skylib-1.7.1.tar.gz",
+            "https://github.com/bazelbuild/bazel-skylib/releases/download/1.7.1/bazel-skylib-1.7.1.tar.gz",
         ],
     )
 
-    # Used for absl/GoogleTest
-    # Note GoogleTest uses "com_googlesource_code_re2" rather than "com_google_re2"
-    github_archive(
-        name = "com_googlesource_code_re2",
-        repo = "https://github.com/google/re2",
-        sha256 = "4e6593ac3c71de1c0f322735bc8b0492a72f66ffccfad76e259fa21c41d27d8a",
-        strip_prefix = "re2-2023-11-01",
-        tag = "2023-11-01",
+    # https://github.com/bazelbuild/rules_foreign_cc
+    http_archive(
+        name = "rules_foreign_cc",
+        sha256 = "4b33d62cf109bcccf286b30ed7121129cc34cf4f4ed9d8a11f38d9108f40ba74",
+        strip_prefix = "rules_foreign_cc-0.11.1",
+        url = "https://github.com/bazelbuild/rules_foreign_cc/releases/download/0.11.1/rules_foreign_cc-0.11.1.tar.gz",
     )
 
     # Abseil, LTS 20230125
@@ -65,26 +63,46 @@ def workspace_load_modules():
     github_archive(
         name = "com_google_absl",
         repo = "https://github.com/abseil/abseil-cpp",
-        sha256 = "987ce98f02eefbaf930d6e38ab16aa05737234d7afbab2d5c4ea7adbe50c28ed",
-        strip_prefix = "abseil-cpp-20230802.1",
-        tag = "20230802.1",
+        sha256 = "733726b8c3a6d39a4120d7e45ea8b41a434cdacde401cba500f14236c49b39dc",
+        strip_prefix = "abseil-cpp-20240116.2",
+        tag = "20240116.2",
+    )
+
+    # Used for absl/GoogleTest
+    # Note GoogleTest uses "com_googlesource_code_re2" rather than "com_google_re2"
+    github_archive(
+        name = "com_googlesource_code_re2",
+        repo_mapping = {"@abseil-cpp": "@com_google_absl"},
+        repo = "https://github.com/google/re2",
+        sha256 = "eb2df807c781601c14a260a507a5bb4509be1ee626024cb45acbd57cb9d4032b",
+        strip_prefix = "re2-2024-07-02",
+        tag = "2024-07-02",
     )
 
     # GoogleTest
     github_archive(
         name = "com_google_googletest",
         repo = "https://github.com/google/googletest",
-        sha256 = "8ad598c73ad796e0d8280b082cebd82a630d73e73cd3c70057938a6501bba5d7",
-        strip_prefix = "googletest-1.14.0",
-        tag = "v1.14.0",
+        sha256 = "7315acb6bf10e99f332c8a43f00d5fbb1ee6ca48c52f6b936991b216c586aaad",
+        strip_prefix = "googletest-1.15.0",
+        tag = "v1.15.0",
+    )
+
+    # Needed because protobuf_deps brings rules_python 0.26.0 which is broken:
+    # https://github.com/bazelbuild/rules_python/issues/1543
+    http_archive(
+        name = "rules_python",
+        sha256 = "5868e73107a8e85d8f323806e60cad7283f34b32163ea6ff1020cf27abef6036",
+        strip_prefix = "rules_python-0.25.0",
+        url = "https://github.com/bazelbuild/rules_python/releases/download/0.25.0/rules_python-0.25.0.tar.gz",
     )
 
     github_archive(
         name = "com_google_protobuf",
         repo = "https://github.com/protocolbuffers/protobuf",
-        sha256 = "8ff511a64fc46ee792d3fe49a5a1bcad6f7dc50dfbba5a28b0e5b979c17f9871",
-        strip_prefix = "protobuf-25.2",
-        tag = "v25.2",
+        sha256 = "e4ff2aeb767da6f4f52485c2e72468960ddfe5262483879ef6ad552e52757a77",
+        strip_prefix = "protobuf-27.2",
+        tag = "v27.2",
     )
 
     # hedron_compile_commands: Used to generate `compile_commands.json` from Bazel.
@@ -94,4 +112,17 @@ def workspace_load_modules():
         commit = "daae6f40adfa5fdb7c89684cbe4d88b691c63b2d",
         repo = "https://github.com/helly25/bazel-compile-commands-extractor",
         sha256 = "43451a32bf271e7ba4635a07f7996d535501f066c0fe8feab04fb0c91dd5986e",
+    )
+
+    # Cannot yet support toolchains_llvm 1.0.0. It enables C++20 modules in a broken way.
+    # Minimum requirements:
+    # * 2023.10.06: https://github.com/bazel-contrib/toolchains_llvm/pull/229: Move minimum supported version to Bazel
+    # * 2024.03.12: https://github.com/bazel-contrib/toolchains_llvm/pull/286: Support LLD linker for Darwin
+    # In order to go past version 1.0.0 we also add the actual fix:
+    # * 2024.06.06: https://github.com/bazel-contrib/toolchains_llvm/pull/337: Force Clang modules with LLVM >= 14q
+    github_archive(
+        name = "toolchains_llvm",
+        commit = "b193952cdb9dd3134f51159d820614ff32dba079",  # https://github.com/bazel-contrib/toolchains_llvm/pull/337
+        repo = "https://github.com/bazel-contrib/toolchains_llvm",
+        integrity = "sha256-eqCfrC/cwTsdE2+DkJQKQmxtlM8mb/nNaZSdg2H8dbk=",
     )


### PR DESCRIPTION
* Prepare matchers also for protobuf >= 26.
* Updated all dependencies.
* Verified protobuf versions 25.2, 26.0, 26.1, 27.0, 27.1, 27.2, 28.0-rc1.
* Added Clang support.
* Updated GH actions.
