### PR TITLE
Added PARSE_TEXT_PROTO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Updated protobuf dev dependency to v30.0 to ensure compatibility.
 * Updated CI matrix to cover more combinations.
+* Implemented (again) the elusive `PARSE_TEXT_PROTO` from 2010 as referenced by clang-tidy's documentation.
 
 # 0.6.1
 

--- a/mbo/proto/parse_text_proto.h
+++ b/mbo/proto/parse_text_proto.h
@@ -113,4 +113,18 @@ inline absl::StatusOr<T> ParseText(
 
 }  // namespace mbo::proto
 
+#ifndef PARSE_TEXT_PROTO
+// The elusive `PARSE_TEXT_PROTO` as supported by clang-tidy:
+// https://clang.llvm.org/docs/ClangFormatStyleOptions.html.
+//
+// Around 2010 writing tests involving Google protobuffers was so annoying but
+// yet so prevalent, that I implemented a type-erasure solution which is the
+// ParseTextProtoOrDie function. However, we could not yet apply C++11's amazing
+// std::source_location and thus had to apply __FILE__ and __LINE__ macro
+// techniques. Today, you really want to use the function. However, clang-tidy
+// still allows for special support, where the macro is known to take a
+// text-proto and thus clang-tidy applies automatic text-proto formatting.
+#define PARSE_TEXT_PROTO(text) ParseTextProtoOrDie(text)
+#endif  // !PARSE_TEXT_PROTO
+
 #endif  // MBO_PROTO_PARSE_TEXT_PROTO_H_

--- a/mbo/proto/parse_text_proto_test.cc
+++ b/mbo/proto/parse_text_proto_test.cc
@@ -78,5 +78,10 @@ TEST_F(ParseTextProtoTest, ParseText) {
           expected));
 }
 
+TEST_F(ParseTextProtoTest, Macro) {
+  const SimpleMessage proto = PARSE_TEXT_PROTO("one: 42");
+  EXPECT_THAT(proto, EqualsProto("one: 42"));
+}
+
 }  // namespace
 }  // namespace mbo::proto


### PR DESCRIPTION
* Implemented (again) the elusive `PARSE_TEXT_PROTO` from 2010 as referenced by clang-tidy's documentation.