### PR TITLE
Deprecate macro PARSE_TEXT_PROTO

### DIFF
--- a/.bcr/patches/bazelmod.patch
+++ b/.bcr/patches/bazelmod.patch
@@ -1,7 +1,7 @@
 diff --git a/MODULE.bazel b/MODULE.bazel
 --- a/MODULE.bazel
 +++ b/MODULE.bazel
-@@ -21,15 +21,15 @@
+@@ -23,15 +23,15 @@
  
  # For local development we include LLVM and Hedron-Compile-Commands.
  # For bazelmod usage these have to be provided by the main module - if necessary.
@@ -17,8 +17,7 @@ diff --git a/MODULE.bazel b/MODULE.bazel
 +bazel_dep(name = "rules_cc", version = "0.0.17")
 +bazel_dep(name = "platforms", version = "0.0.10")
  bazel_dep(name = "abseil-cpp", version = "20250127.0", repo_name = "com_google_absl")
--bazel_dep(name = "re2", version = "2024-07-02.bcr.1", repo_name = "com_googlesource_code_re2")
-+bazel_dep(name = "re2", version = "2024-07-02", repo_name = "com_googlesource_code_re2")
+ bazel_dep(name = "re2", version = "2024-07-02.bcr.1", repo_name = "com_googlesource_code_re2")
  bazel_dep(name = "googletest", version = "1.16.0", repo_name = "com_google_googletest")
 -bazel_dep(name = "rules_python", version = "1.2.0")
 -bazel_dep(name = "protobuf", version = "30.0", repo_name = "com_google_protobuf")

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -14,22 +14,25 @@ Checks: >
   -cppcoreguidelines-avoid-const-or-ref-data-members,
   -fuchsia*,
   google-*,
+  -google-build-using-namespace,
   -hicpp-no-assembler,
   -llvm-else-after-return,
-  llvm-header-guard,
   -llvm-include-order,
   -llvmlibc-*,
   misc-*,
   modernize-*,
   -modernize-use-nodiscard,
+  -modernize-use-std-format,
   -modernize-use-trailing-return-type,
   performance-*,
+  -performance-enum-size,
   portability-*,
   readability-*,
+  -readability-avoid-nested-conditional-operator,
   -readability-else-after-return,
+  -readability-redundant-inline-specifier,
 
 WarningsAsErrors: true
-AnalyzeTemporaryDtors: false
 FormatStyle:       '.clang-format'
 CheckOptions:
   - key:             bugprone-signed-char-misuse.CharTypdefsToIgnore
@@ -62,6 +65,8 @@ CheckOptions:
     value:           'NULL'
   - key:             performance-unnecessary-value-param.AllowedTypes
     value:           'absl::Status;absl::StatusOr;std::string_view'
+  - key:             readability-function-cognitive-complexity.Threshold
+    value:           '25'
   - key:             readability-braces-around-statements.ShortStatementLines
     value:           '1'
   - key:             readability-identifier-length.IgnoredLoopCounterNames

--- a/.github/workflows/bazelmod.patch
+++ b/.github/workflows/bazelmod.patch
@@ -1,7 +1,7 @@
 diff --git a/MODULE.bazel b/MODULE.bazel
 --- a/MODULE.bazel
 +++ b/MODULE.bazel
-@@ -21,15 +21,15 @@
+@@ -23,15 +23,15 @@
  
  # For local development we include LLVM and Hedron-Compile-Commands.
  # For bazelmod usage these have to be provided by the main module - if necessary.
@@ -17,8 +17,7 @@ diff --git a/MODULE.bazel b/MODULE.bazel
 +bazel_dep(name = "rules_cc", version = "0.0.17")
 +bazel_dep(name = "platforms", version = "0.0.10")
  bazel_dep(name = "abseil-cpp", version = "20250127.0", repo_name = "com_google_absl")
--bazel_dep(name = "re2", version = "2024-07-02.bcr.1", repo_name = "com_googlesource_code_re2")
-+bazel_dep(name = "re2", version = "2024-07-02", repo_name = "com_googlesource_code_re2")
+ bazel_dep(name = "re2", version = "2024-07-02.bcr.1", repo_name = "com_googlesource_code_re2")
  bazel_dep(name = "googletest", version = "1.16.0", repo_name = "com_google_googletest")
 -bazel_dep(name = "rules_python", version = "1.2.0")
 -bazel_dep(name = "protobuf", version = "30.0", repo_name = "com_google_protobuf")

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -126,7 +126,7 @@ jobs:
         compiler: [clang]
         llvm_version: [19.1.6]
         bazel_config: [opt]
-        module_version: [proto27]
+        module_version: [proto27.0]
 
     uses: ./.github/workflows/test.yml
     with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -116,3 +116,24 @@ jobs:
       llvm_version: "${{ matrix.llvm_version }}"
       bazel_config: ${{ matrix.bazel_config }}
       proto_version: "${{ matrix.proto_version }}"
+
+  test-bcr:
+    needs: [pre-commit, test-gcc]
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        bazel_mode: [bzlmod]
+        compiler: [clang]
+        llvm_version: [19.1.6]
+        bazel_config: [opt]
+        module_version: [0.4.2]
+
+    uses: ./.github/workflows/test.yml
+    with:
+      continue-on-error: true
+      os: ${{ matrix.os }}
+      bazel_mode: ${{ matrix.bazel_mode }}
+      compiler: ${{ matrix.compiler }}
+      llvm_version: ${{ matrix.llvm_version }}
+      bazel_config: ${{ matrix.bazel_config }}
+      module_version: ${{ matrix.module_version }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -126,7 +126,7 @@ jobs:
         compiler: [clang]
         llvm_version: [19.1.6]
         bazel_config: [opt]
-        module_version: [0.4.2]
+        module_version: [proto27]
 
     uses: ./.github/workflows/test.yml
     with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -122,10 +122,13 @@ jobs:
           elif [ "${{ inputs.bazel_config }}" == "opt" ]; then
             BAZEL_ARGS+=("-c" "opt")
           else
-            echo "ERROR: Matrix/Input var 'bazel_config' must be one of [asan, fastbuild, opt]."
+            echo "ERROR: Matrix/Input var 'bazel_config' must be one of [asan, cpp23, fastbuild, opt]."
           fi
           if [ -n "${{ inputs.module_version }}" ]; then
             cp "bazelmod/MODULE.${{ inputs.module_version }}.bazel" MODULE.bazel
+            if [ -n "${{ inputs.proto_version }}" ]; then
+              echo "ERROR: Matrix/Input var 'module_version' cannot be used together with var 'proto_version'."
+            fi
           fi
           echo "BAZEL_INIT: ${BAZEL_INIT[@]}"
           echo "BAZEL_ARGS: ${BAZEL_ARGS[@]}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 0.6.3
 
 * Made macro `PARSE_TEXT_PROTO` issue a deprecation warning.
+* Raise minimum zlib version when built with proto version 27.0 for MacOS.
 
 # 0.6.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.6.3
+
+* Made macro `PARSE_TEXT_PROTO` issue a deprecation warning.
+
 # 0.6.2
 
 * Updated protobuf dev dependency to v30.0 to ensure compatibility.
@@ -8,6 +12,7 @@
 
 * Updated license/copyright to add SPDX headers.
 * Updated internal tooling.
+* Released to baze-central-registry for the first time.
 
 # 0.6.0
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -13,10 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""Module helly25/proto."""
+
 # Due to flag and test references to the repo name we use the old name for now.
 module(
     name = "helly25_proto",
-    version = "0.6.2",
+    version = "0.6.3",
 )
 
 # For local development we include LLVM and Hedron-Compile-Commands.

--- a/bazelmod/MODULE.proto27.0.bazel
+++ b/bazelmod/MODULE.proto27.0.bazel
@@ -34,4 +34,5 @@ bazel_dep(name = "abseil-cpp", version = "20250127.0", repo_name = "com_google_a
 bazel_dep(name = "re2", version = "2024-07-02.bcr.1", repo_name = "com_googlesource_code_re2")
 bazel_dep(name = "googletest", version = "1.16.0", repo_name = "com_google_googletest")
 bazel_dep(name = "rules_python", version = "0.33.2")
+bazel_dep(name = "zlib", version = "1.3.1.bcr.1")  # Need to override min version for MacOS
 bazel_dep(name = "protobuf", version = "27.0", repo_name = "com_google_protobuf")

--- a/bazelmod/MODULE.proto27.0.bazel
+++ b/bazelmod/MODULE.proto27.0.bazel
@@ -12,8 +12,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+"""Module helly25/proto with proto version 27.0."""
+
 # Due to flag and test references to the repo name we use the old name for now.
-"""Bazelmod file for protobuf version 27.0"""
 module(
     name = "helly25_proto",
     version = "0.0.0",
@@ -29,7 +31,7 @@ bazel_dep(name = "bazel_skylib", version = "1.7.1")
 bazel_dep(name = "rules_cc", version = "0.0.17")
 bazel_dep(name = "platforms", version = "0.0.10")
 bazel_dep(name = "abseil-cpp", version = "20250127.0", repo_name = "com_google_absl")
-bazel_dep(name = "re2", version = "2024-07-02", repo_name = "com_googlesource_code_re2")
+bazel_dep(name = "re2", version = "2024-07-02.bcr.1", repo_name = "com_googlesource_code_re2")
 bazel_dep(name = "googletest", version = "1.16.0", repo_name = "com_google_googletest")
 bazel_dep(name = "rules_python", version = "0.33.2")
 bazel_dep(name = "protobuf", version = "27.0", repo_name = "com_google_protobuf")

--- a/bazelmod/MODULE.proto28.0.bazel
+++ b/bazelmod/MODULE.proto28.0.bazel
@@ -12,8 +12,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+"""Module helly25/proto with proto version 28.0."""
+
 # Due to flag and test references to the repo name we use the old name for now.
-"""Bazelmod file for protobuf version 28.0"""
 module(
     name = "helly25_proto",
     version = "0.0.0",
@@ -27,7 +29,7 @@ bazel_dep(name = "bazel_skylib", version = "1.7.1")
 bazel_dep(name = "rules_cc", version = "0.0.17")
 bazel_dep(name = "platforms", version = "0.0.10")
 bazel_dep(name = "abseil-cpp", version = "20250127.0", repo_name = "com_google_absl")
-bazel_dep(name = "re2", version = "2024-07-02", repo_name = "com_googlesource_code_re2")
+bazel_dep(name = "re2", version = "2024-07-02.bcr.1", repo_name = "com_googlesource_code_re2")
 bazel_dep(name = "googletest", version = "1.16.0", repo_name = "com_google_googletest")
 bazel_dep(name = "rules_python", version = "0.35.0")
 bazel_dep(name = "protobuf", version = "28.0", repo_name = "com_google_protobuf")

--- a/bazelmod/MODULE.proto29.0.bazel
+++ b/bazelmod/MODULE.proto29.0.bazel
@@ -12,8 +12,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+"""Module helly25/proto with proto version 29.0."""
+
 # Due to flag and test references to the repo name we use the old name for now.
-"""Bazelmod file for protobuf version 29.0"""
 module(
     name = "helly25_proto",
     version = "0.0.0",
@@ -27,7 +29,7 @@ bazel_dep(name = "bazel_skylib", version = "1.7.1")
 bazel_dep(name = "rules_cc", version = "0.0.17")
 bazel_dep(name = "platforms", version = "0.0.10")
 bazel_dep(name = "abseil-cpp", version = "20250127.0", repo_name = "com_google_absl")
-bazel_dep(name = "re2", version = "2024-07-02", repo_name = "com_googlesource_code_re2")
+bazel_dep(name = "re2", version = "2024-07-02.bcr.1", repo_name = "com_googlesource_code_re2")
 bazel_dep(name = "googletest", version = "1.16.0", repo_name = "com_google_googletest")
 bazel_dep(name = "rules_python", version = "1.0.0")
 bazel_dep(name = "protobuf", version = "29.0", repo_name = "com_google_protobuf")

--- a/bazelmod/MODULE.proto29.1.bazel
+++ b/bazelmod/MODULE.proto29.1.bazel
@@ -12,8 +12,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+"""Module helly25/proto with proto version 29.1."""
+
 # Due to flag and test references to the repo name we use the old name for now.
-"""Bazelmod file for protobuf version 29.1"""
 module(
     name = "helly25_proto",
     version = "0.0.0",

--- a/bazelmod/MODULE.proto30.0.bazel
+++ b/bazelmod/MODULE.proto30.0.bazel
@@ -13,8 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""Module helly25/proto with proto version 30.0."""
+
 # Due to flag and test references to the repo name we use the old name for now.
-"""Bazelmod file for protobuf version 30.0"""
 module(
     name = "helly25_proto",
     version = "0.0.0",

--- a/fixes.yaml
+++ b/fixes.yaml
@@ -1,0 +1,1316 @@
+---
+MainSourceFile:  '/home/marcus/helly25/proto/mbo/proto/matchers.cc'
+Diagnostics:
+  - DiagnosticName:  misc-include-cleaner
+    DiagnosticMessage:
+      Message:         included header algorithm is not used directly
+      FilePath:        'mbo/proto/matchers.cc'
+      FileOffset:      742
+      Replacements:
+        - FilePath:        'mbo/proto/matchers.cc'
+          Offset:          742
+          Length:          21
+          ReplacementText: ''
+    Level:           Warning
+    BuildDirectory:  '/home/marcus/helly25/proto'
+  - DiagnosticName:  misc-include-cleaner
+    DiagnosticMessage:
+      Message:         'no header providing "re2::StringPiece" is directly included'
+      FilePath:        'mbo/proto/matchers.cc'
+      FileOffset:      1182
+      Replacements:
+        - FilePath:        'mbo/proto/matchers.cc'
+          Offset:          1116
+          Length:          0
+          ReplacementText: "#include \"re2/stringpiece.h\"\n"
+    Level:           Warning
+    BuildDirectory:  '/home/marcus/helly25/proto'
+  - DiagnosticName:  misc-include-cleaner
+    DiagnosticMessage:
+      Message:         'no header providing "GOOGLE_PROTOBUF_VERSION" is directly included'
+      FilePath:        'mbo/proto/matchers.cc'
+      FileOffset:      1695
+      Replacements:
+        - FilePath:        'mbo/proto/matchers.cc'
+          Offset:          1029
+          Length:          0
+          ReplacementText: "#include \"google/protobuf/stubs/common.h\"\n"
+    Level:           Warning
+    BuildDirectory:  '/home/marcus/helly25/proto'
+  - DiagnosticName:  misc-include-cleaner
+    DiagnosticMessage:
+      Message:         'no header providing "google::protobuf::Message" is directly included'
+      FilePath:        'mbo/proto/matchers.cc'
+      FileOffset:      2407
+      Replacements:
+        - FilePath:        'mbo/proto/matchers.cc'
+          Offset:          1029
+          Length:          0
+          ReplacementText: "#include \"google/protobuf/message.h\"\n"
+    Level:           Warning
+    BuildDirectory:  '/home/marcus/helly25/proto'
+  - DiagnosticName:  readability-identifier-length
+    DiagnosticMessage:
+      Message:         'parameter name ''p'' is too short, expected at least 3 characters'
+      FilePath:        'mbo/proto/matchers.cc'
+      FileOffset:      2817
+      Replacements:    []
+    Level:           Warning
+    BuildDirectory:  '/home/marcus/helly25/proto'
+  - DiagnosticName:  readability-identifier-length
+    DiagnosticMessage:
+      Message:         'parameter name ''q'' is too short, expected at least 3 characters'
+      FilePath:        'mbo/proto/matchers.cc'
+      FileOffset:      2855
+      Replacements:    []
+    Level:           Warning
+    BuildDirectory:  '/home/marcus/helly25/proto'
+  - DiagnosticName:  misc-use-internal-linkage
+    DiagnosticMessage:
+      Message:         'function ''JoinStringPieces'' can be made static or moved into an anonymous namespace to enforce internal linkage'
+      FilePath:        'mbo/proto/matchers.cc'
+      FileOffset:      2953
+      Replacements:
+        - FilePath:        'mbo/proto/matchers.cc'
+          Offset:          2941
+          Length:          0
+          ReplacementText: 'static '
+    Level:           Warning
+    BuildDirectory:  '/home/marcus/helly25/proto'
+  - DiagnosticName:  misc-include-cleaner
+    DiagnosticMessage:
+      Message:         'no header providing "std::stringstream" is directly included'
+      FilePath:        'mbo/proto/matchers.cc'
+      FileOffset:      3033
+      Replacements:
+        - FilePath:        'mbo/proto/matchers.cc'
+          Offset:          763
+          Length:          0
+          ReplacementText: "#include <sstream>\n"
+    Level:           Warning
+    BuildDirectory:  '/home/marcus/helly25/proto'
+  - DiagnosticName:  readability-redundant-string-init
+    DiagnosticMessage:
+      Message:         redundant string initialization
+      FilePath:        'mbo/proto/matchers.cc'
+      FileOffset:      3073
+      Replacements:
+        - FilePath:        'mbo/proto/matchers.cc'
+          Offset:          3073
+          Length:          8
+          ReplacementText: sep
+    Level:           Warning
+    BuildDirectory:  '/home/marcus/helly25/proto'
+  - DiagnosticName:  misc-include-cleaner
+    DiagnosticMessage:
+      Message:         'no header providing "std::vector" is directly included'
+      FilePath:        'mbo/proto/matchers.cc'
+      FileOffset:      3263
+      Replacements:
+        - FilePath:        'mbo/proto/matchers.cc'
+          Offset:          804
+          Length:          0
+          ReplacementText: "#include <vector>\n"
+    Level:           Warning
+    BuildDirectory:  '/home/marcus/helly25/proto'
+  - DiagnosticName:  misc-include-cleaner
+    DiagnosticMessage:
+      Message:         'no header providing "google::protobuf::FieldDescriptor" is directly included'
+      FilePath:        'mbo/proto/matchers.cc'
+      FileOffset:      3296
+      Replacements:
+        - FilePath:        'mbo/proto/matchers.cc'
+          Offset:          987
+          Length:          0
+          ReplacementText: "#include \"google/protobuf/descriptor.h\"\n"
+    Level:           Warning
+    BuildDirectory:  '/home/marcus/helly25/proto'
+  - DiagnosticName:  misc-use-internal-linkage
+    DiagnosticMessage:
+      Message:         'function ''GetFieldDescriptors'' can be made static or moved into an anonymous namespace to enforce internal linkage'
+      FilePath:        'mbo/proto/matchers.cc'
+      FileOffset:      3314
+      Replacements:
+        - FilePath:        'mbo/proto/matchers.cc'
+          Offset:          3258
+          Length:          0
+          ReplacementText: 'static '
+    Level:           Warning
+    BuildDirectory:  '/home/marcus/helly25/proto'
+  - DiagnosticName:  misc-include-cleaner
+    DiagnosticMessage:
+      Message:         'no header providing "google::protobuf::Descriptor" is directly included'
+      FilePath:        'mbo/proto/matchers.cc'
+      FileOffset:      3365
+      Replacements:    []
+    Level:           Warning
+    BuildDirectory:  '/home/marcus/helly25/proto'
+  - DiagnosticName:  misc-include-cleaner
+    DiagnosticMessage:
+      Message:         'no header providing "google::protobuf::DescriptorPool" is directly included'
+      FilePath:        'mbo/proto/matchers.cc'
+      FileOffset:      3610
+      Replacements:    []
+    Level:           Warning
+    BuildDirectory:  '/home/marcus/helly25/proto'
+  - DiagnosticName:  misc-use-internal-linkage
+    DiagnosticMessage:
+      Message:         'function ''SetIgnoredFieldsOrDie'' can be made static or moved into an anonymous namespace to enforce internal linkage'
+      FilePath:        'mbo/proto/matchers.cc'
+      FileOffset:      4282
+      Replacements:
+        - FilePath:        'mbo/proto/matchers.cc'
+          Offset:          4277
+          Length:          0
+          ReplacementText: 'static '
+    Level:           Warning
+    BuildDirectory:  '/home/marcus/helly25/proto'
+  - DiagnosticName:  misc-include-cleaner
+    DiagnosticMessage:
+      Message:         'no header providing "google::protobuf::util::MessageDifferencer" is directly included'
+      FilePath:        'mbo/proto/matchers.cc'
+      FileOffset:      4445
+      Replacements:
+        - FilePath:        'mbo/proto/matchers.cc'
+          Offset:          1070
+          Length:          0
+          ReplacementText: "#include \"google/protobuf/util/message_differencer.h\"\n"
+    Level:           Warning
+    BuildDirectory:  '/home/marcus/helly25/proto'
+  - DiagnosticName:  modernize-loop-convert
+    DiagnosticMessage:
+      Message:         use range-based for loop instead
+      FilePath:        'mbo/proto/matchers.cc'
+      FileOffset:      4659
+      Replacements:
+        - FilePath:        'mbo/proto/matchers.cc'
+          Offset:          4663
+          Length:          146
+          ReplacementText: '(auto & ignore_descriptor : ignore_descriptors)'
+        - FilePath:        'mbo/proto/matchers.cc'
+          Offset:          4843
+          Length:          3
+          ReplacementText: ignore_descriptor
+    Level:           Warning
+    BuildDirectory:  '/home/marcus/helly25/proto'
+  - DiagnosticName:  hicpp-use-auto
+    DiagnosticMessage:
+      Message:         use auto when declaring iterators
+      FilePath:        'mbo/proto/matchers.cc'
+      FileOffset:      4664
+      Replacements:    []
+    Notes:
+      - Message:         this fix will not be applied because it overlaps with another fix
+        FilePath:        ''
+        FileOffset:      0
+        Replacements:    []
+    Level:           Warning
+    BuildDirectory:  '/home/marcus/helly25/proto'
+  - DiagnosticName:  misc-unused-parameters
+    DiagnosticMessage:
+      Message:         'parameter ''message1'' is unused'
+      FilePath:        'mbo/proto/matchers.cc'
+      FileOffset:      5252
+      Replacements:
+        - FilePath:        'mbo/proto/matchers.cc'
+          Offset:          5252
+          Length:          8
+          ReplacementText: ' /*message1*/'
+    Level:           Warning
+    BuildDirectory:  '/home/marcus/helly25/proto'
+  - DiagnosticName:  misc-unused-parameters
+    DiagnosticMessage:
+      Message:         'parameter ''message2'' is unused'
+      FilePath:        'mbo/proto/matchers.cc'
+      FileOffset:      5303
+      Replacements:
+        - FilePath:        'mbo/proto/matchers.cc'
+          Offset:          5303
+          Length:          8
+          ReplacementText: ' /*message2*/'
+    Level:           Warning
+    BuildDirectory:  '/home/marcus/helly25/proto'
+  - DiagnosticName:  misc-include-cleaner
+    DiagnosticMessage:
+      Message:         'no header providing "size_t" is directly included'
+      FilePath:        'mbo/proto/matchers.cc'
+      FileOffset:      5630
+      Replacements:
+        - FilePath:        'mbo/proto/matchers.cc'
+          Offset:          763
+          Length:          0
+          ReplacementText: "#include <cstddef>\n"
+    Level:           Warning
+    BuildDirectory:  '/home/marcus/helly25/proto'
+  - DiagnosticName:  readability-identifier-length
+    DiagnosticMessage:
+      Message:         'parameter name ''s'' is too short, expected at least 3 characters'
+      FilePath:        'mbo/proto/matchers.cc'
+      FileOffset:      6554
+      Replacements:    []
+    Level:           Warning
+    BuildDirectory:  '/home/marcus/helly25/proto'
+  - DiagnosticName:  readability-identifier-length
+    DiagnosticMessage:
+      Message:         'parameter name ''x'' is too short, expected at least 3 characters'
+      FilePath:        'mbo/proto/matchers.cc'
+      FileOffset:      6575
+      Replacements:    []
+    Level:           Warning
+    BuildDirectory:  '/home/marcus/helly25/proto'
+  - DiagnosticName:  misc-include-cleaner
+    DiagnosticMessage:
+      Message:         'no header providing "memcmp" is directly included'
+      FilePath:        'mbo/proto/matchers.cc'
+      FileOffset:      6732
+      Replacements:
+        - FilePath:        'mbo/proto/matchers.cc'
+          Offset:          763
+          Length:          0
+          ReplacementText: "#include <cstring>\n"
+    Level:           Warning
+    BuildDirectory:  '/home/marcus/helly25/proto'
+  - DiagnosticName:  misc-use-internal-linkage
+    DiagnosticMessage:
+      Message:         'function ''ParseFieldPathOrDie'' can be made static or moved into an anonymous namespace to enforce internal linkage'
+      FilePath:        'mbo/proto/matchers.cc'
+      FileOffset:      6998
+      Replacements:
+        - FilePath:        'mbo/proto/matchers.cc'
+          Offset:          6925
+          Length:          0
+          ReplacementText: 'static '
+    Level:           Warning
+    BuildDirectory:  '/home/marcus/helly25/proto'
+  - DiagnosticName:  readability-function-cognitive-complexity
+    DiagnosticMessage:
+      Message:         'function ''ParseFieldPathOrDie'' has cognitive complexity of 87 (threshold 25)'
+      FilePath:        'mbo/proto/matchers.cc'
+      FileOffset:      6998
+      Replacements:    []
+    Notes:
+      - Message:         '+1, including nesting penalty of 0, nesting level increased to 1'
+        FilePath:        'mbo/proto/matchers.cc'
+        FileOffset:      7787
+        Replacements:    []
+      - Message:         '+2, including nesting penalty of 1, nesting level increased to 2'
+        FilePath:        'mbo/proto/matchers.cc'
+        FileOffset:      7869
+        Replacements:    []
+      - Message:         '+1'
+        FilePath:        'mbo/proto/matchers.cc'
+        FileOffset:      7915
+        Replacements:    []
+      - Message:         '+3, including nesting penalty of 2, nesting level increased to 3'
+        FilePath:        'mbo/proto/matchers.cc'
+        FileOffset:      7949
+        Replacements:    []
+      - Message:         'expanded from macro ''ABSL_LOG'''
+        FilePath:        'external/abseil-cpp~/absl/log/absl_log.h'
+        FileOffset:      1461
+        Replacements:    []
+      - Message:         'expanded from macro ''ABSL_LOG_INTERNAL_LOG_IMPL'''
+        FilePath:        'external/abseil-cpp~/absl/log/internal/log_impl.h'
+        FileOffset:      910
+        Replacements:    []
+      - Message:         expanded from here
+        FilePath:        ''
+        FileOffset:      0
+        Replacements:    []
+      - Message:         'expanded from macro ''ABSL_LOG_INTERNAL_CONDITION_FATAL'''
+        FilePath:        'external/abseil-cpp~/absl/log/internal/conditions.h'
+        FileOffset:      9257
+        Replacements:    []
+      - Message:         expanded from here
+        FilePath:        ''
+        FileOffset:      0
+        Replacements:    []
+      - Message:         'expanded from macro ''ABSL_LOG_INTERNAL_STATELESS_CONDITION'''
+        FilePath:        'external/abseil-cpp~/absl/log/internal/conditions.h'
+        FileOffset:      2485
+        Replacements:    []
+      - Message:         '+4, including nesting penalty of 3, nesting level increased to 4'
+        FilePath:        'mbo/proto/matchers.cc'
+        FileOffset:      7949
+        Replacements:    []
+      - Message:         'expanded from macro ''ABSL_LOG'''
+        FilePath:        'external/abseil-cpp~/absl/log/absl_log.h'
+        FileOffset:      1461
+        Replacements:    []
+      - Message:         'expanded from macro ''ABSL_LOG_INTERNAL_LOG_IMPL'''
+        FilePath:        'external/abseil-cpp~/absl/log/internal/log_impl.h'
+        FileOffset:      910
+        Replacements:    []
+      - Message:         expanded from here
+        FilePath:        ''
+        FileOffset:      0
+        Replacements:    []
+      - Message:         'expanded from macro ''ABSL_LOG_INTERNAL_CONDITION_FATAL'''
+        FilePath:        'external/abseil-cpp~/absl/log/internal/conditions.h'
+        FileOffset:      9257
+        Replacements:    []
+      - Message:         expanded from here
+        FilePath:        ''
+        FileOffset:      0
+        Replacements:    []
+      - Message:         'expanded from macro ''ABSL_LOG_INTERNAL_STATELESS_CONDITION'''
+        FilePath:        'external/abseil-cpp~/absl/log/internal/conditions.h'
+        FileOffset:      2677
+        Replacements:    []
+      - Message:         '+2, including nesting penalty of 1, nesting level increased to 2'
+        FilePath:        'mbo/proto/matchers.cc'
+        FileOffset:      8306
+        Replacements:    []
+      - Message:         '+1'
+        FilePath:        'mbo/proto/matchers.cc'
+        FileOffset:      8375
+        Replacements:    []
+      - Message:         '+3, including nesting penalty of 2, nesting level increased to 3'
+        FilePath:        'mbo/proto/matchers.cc'
+        FileOffset:      8428
+        Replacements:    []
+      - Message:         '+4, including nesting penalty of 3, nesting level increased to 4'
+        FilePath:        'mbo/proto/matchers.cc'
+        FileOffset:      8536
+        Replacements:    []
+      - Message:         'expanded from macro ''ABSL_CHECK'''
+        FilePath:        'external/abseil-cpp~/absl/log/absl_check.h'
+        FileOffset:      1825
+        Replacements:    []
+      - Message:         'expanded from macro ''ABSL_LOG_INTERNAL_CHECK_IMPL'''
+        FilePath:        'external/abseil-cpp~/absl/log/internal/check_impl.h'
+        FileOffset:      962
+        Replacements:    []
+      - Message:         'expanded from macro ''ABSL_LOG_INTERNAL_CONDITION_FATAL'''
+        FilePath:        'external/abseil-cpp~/absl/log/internal/conditions.h'
+        FileOffset:      9257
+        Replacements:    []
+      - Message:         expanded from here
+        FilePath:        ''
+        FileOffset:      0
+        Replacements:    []
+      - Message:         'expanded from macro ''ABSL_LOG_INTERNAL_STATELESS_CONDITION'''
+        FilePath:        'external/abseil-cpp~/absl/log/internal/conditions.h'
+        FileOffset:      2485
+        Replacements:    []
+      - Message:         '+5, including nesting penalty of 4, nesting level increased to 5'
+        FilePath:        'mbo/proto/matchers.cc'
+        FileOffset:      8536
+        Replacements:    []
+      - Message:         'expanded from macro ''ABSL_CHECK'''
+        FilePath:        'external/abseil-cpp~/absl/log/absl_check.h'
+        FileOffset:      1825
+        Replacements:    []
+      - Message:         'expanded from macro ''ABSL_LOG_INTERNAL_CHECK_IMPL'''
+        FilePath:        'external/abseil-cpp~/absl/log/internal/check_impl.h'
+        FileOffset:      962
+        Replacements:    []
+      - Message:         'expanded from macro ''ABSL_LOG_INTERNAL_CONDITION_FATAL'''
+        FilePath:        'external/abseil-cpp~/absl/log/internal/conditions.h'
+        FileOffset:      9257
+        Replacements:    []
+      - Message:         expanded from here
+        FilePath:        ''
+        FileOffset:      0
+        Replacements:    []
+      - Message:         'expanded from macro ''ABSL_LOG_INTERNAL_STATELESS_CONDITION'''
+        FilePath:        'external/abseil-cpp~/absl/log/internal/conditions.h'
+        FileOffset:      2677
+        Replacements:    []
+      - Message:         '+1'
+        FilePath:        'mbo/proto/matchers.cc'
+        FileOffset:      8536
+        Replacements:    []
+      - Message:         'expanded from macro ''ABSL_CHECK'''
+        FilePath:        'external/abseil-cpp~/absl/log/absl_check.h'
+        FileOffset:      1825
+        Replacements:    []
+      - Message:         'expanded from macro ''ABSL_LOG_INTERNAL_CHECK_IMPL'''
+        FilePath:        'external/abseil-cpp~/absl/log/internal/check_impl.h'
+        FileOffset:      1068
+        Replacements:    []
+      - Message:         'expanded from macro ''ABSL_PREDICT_FALSE'''
+        FilePath:        'external/abseil-cpp~/absl/base/optimization.h'
+        FileOffset:      7311
+        Replacements:    []
+      - Message:         '+1, nesting level increased to 3'
+        FilePath:        'mbo/proto/matchers.cc'
+        FileOffset:      8656
+        Replacements:    []
+      - Message:         '+4, including nesting penalty of 3, nesting level increased to 4'
+        FilePath:        'mbo/proto/matchers.cc'
+        FileOffset:      8862
+        Replacements:    []
+      - Message:         'expanded from macro ''ABSL_CHECK'''
+        FilePath:        'external/abseil-cpp~/absl/log/absl_check.h'
+        FileOffset:      1825
+        Replacements:    []
+      - Message:         'expanded from macro ''ABSL_LOG_INTERNAL_CHECK_IMPL'''
+        FilePath:        'external/abseil-cpp~/absl/log/internal/check_impl.h'
+        FileOffset:      962
+        Replacements:    []
+      - Message:         'expanded from macro ''ABSL_LOG_INTERNAL_CONDITION_FATAL'''
+        FilePath:        'external/abseil-cpp~/absl/log/internal/conditions.h'
+        FileOffset:      9257
+        Replacements:    []
+      - Message:         expanded from here
+        FilePath:        ''
+        FileOffset:      0
+        Replacements:    []
+      - Message:         'expanded from macro ''ABSL_LOG_INTERNAL_STATELESS_CONDITION'''
+        FilePath:        'external/abseil-cpp~/absl/log/internal/conditions.h'
+        FileOffset:      2485
+        Replacements:    []
+      - Message:         '+5, including nesting penalty of 4, nesting level increased to 5'
+        FilePath:        'mbo/proto/matchers.cc'
+        FileOffset:      8862
+        Replacements:    []
+      - Message:         'expanded from macro ''ABSL_CHECK'''
+        FilePath:        'external/abseil-cpp~/absl/log/absl_check.h'
+        FileOffset:      1825
+        Replacements:    []
+      - Message:         'expanded from macro ''ABSL_LOG_INTERNAL_CHECK_IMPL'''
+        FilePath:        'external/abseil-cpp~/absl/log/internal/check_impl.h'
+        FileOffset:      962
+        Replacements:    []
+      - Message:         'expanded from macro ''ABSL_LOG_INTERNAL_CONDITION_FATAL'''
+        FilePath:        'external/abseil-cpp~/absl/log/internal/conditions.h'
+        FileOffset:      9257
+        Replacements:    []
+      - Message:         expanded from here
+        FilePath:        ''
+        FileOffset:      0
+        Replacements:    []
+      - Message:         'expanded from macro ''ABSL_LOG_INTERNAL_STATELESS_CONDITION'''
+        FilePath:        'external/abseil-cpp~/absl/log/internal/conditions.h'
+        FileOffset:      2677
+        Replacements:    []
+      - Message:         '+1'
+        FilePath:        'mbo/proto/matchers.cc'
+        FileOffset:      8862
+        Replacements:    []
+      - Message:         'expanded from macro ''ABSL_CHECK'''
+        FilePath:        'external/abseil-cpp~/absl/log/absl_check.h'
+        FileOffset:      1825
+        Replacements:    []
+      - Message:         'expanded from macro ''ABSL_LOG_INTERNAL_CHECK_IMPL'''
+        FilePath:        'external/abseil-cpp~/absl/log/internal/check_impl.h'
+        FileOffset:      1068
+        Replacements:    []
+      - Message:         'expanded from macro ''ABSL_PREDICT_FALSE'''
+        FilePath:        'external/abseil-cpp~/absl/base/optimization.h'
+        FileOffset:      7311
+        Replacements:    []
+      - Message:         '+1, nesting level increased to 2'
+        FilePath:        'mbo/proto/matchers.cc'
+        FileOffset:      8983
+        Replacements:    []
+      - Message:         '+3, including nesting penalty of 2, nesting level increased to 3'
+        FilePath:        'mbo/proto/matchers.cc'
+        FileOffset:      9142
+        Replacements:    []
+      - Message:         'expanded from macro ''ABSL_CHECK'''
+        FilePath:        'external/abseil-cpp~/absl/log/absl_check.h'
+        FileOffset:      1825
+        Replacements:    []
+      - Message:         'expanded from macro ''ABSL_LOG_INTERNAL_CHECK_IMPL'''
+        FilePath:        'external/abseil-cpp~/absl/log/internal/check_impl.h'
+        FileOffset:      962
+        Replacements:    []
+      - Message:         'expanded from macro ''ABSL_LOG_INTERNAL_CONDITION_FATAL'''
+        FilePath:        'external/abseil-cpp~/absl/log/internal/conditions.h'
+        FileOffset:      9257
+        Replacements:    []
+      - Message:         expanded from here
+        FilePath:        ''
+        FileOffset:      0
+        Replacements:    []
+      - Message:         'expanded from macro ''ABSL_LOG_INTERNAL_STATELESS_CONDITION'''
+        FilePath:        'external/abseil-cpp~/absl/log/internal/conditions.h'
+        FileOffset:      2485
+        Replacements:    []
+      - Message:         '+4, including nesting penalty of 3, nesting level increased to 4'
+        FilePath:        'mbo/proto/matchers.cc'
+        FileOffset:      9142
+        Replacements:    []
+      - Message:         'expanded from macro ''ABSL_CHECK'''
+        FilePath:        'external/abseil-cpp~/absl/log/absl_check.h'
+        FileOffset:      1825
+        Replacements:    []
+      - Message:         'expanded from macro ''ABSL_LOG_INTERNAL_CHECK_IMPL'''
+        FilePath:        'external/abseil-cpp~/absl/log/internal/check_impl.h'
+        FileOffset:      962
+        Replacements:    []
+      - Message:         'expanded from macro ''ABSL_LOG_INTERNAL_CONDITION_FATAL'''
+        FilePath:        'external/abseil-cpp~/absl/log/internal/conditions.h'
+        FileOffset:      9257
+        Replacements:    []
+      - Message:         expanded from here
+        FilePath:        ''
+        FileOffset:      0
+        Replacements:    []
+      - Message:         'expanded from macro ''ABSL_LOG_INTERNAL_STATELESS_CONDITION'''
+        FilePath:        'external/abseil-cpp~/absl/log/internal/conditions.h'
+        FileOffset:      2677
+        Replacements:    []
+      - Message:         '+1'
+        FilePath:        'mbo/proto/matchers.cc'
+        FileOffset:      9142
+        Replacements:    []
+      - Message:         'expanded from macro ''ABSL_CHECK'''
+        FilePath:        'external/abseil-cpp~/absl/log/absl_check.h'
+        FileOffset:      1825
+        Replacements:    []
+      - Message:         'expanded from macro ''ABSL_LOG_INTERNAL_CHECK_IMPL'''
+        FilePath:        'external/abseil-cpp~/absl/log/internal/check_impl.h'
+        FileOffset:      1068
+        Replacements:    []
+      - Message:         'expanded from macro ''ABSL_PREDICT_FALSE'''
+        FilePath:        'external/abseil-cpp~/absl/base/optimization.h'
+        FileOffset:      7311
+        Replacements:    []
+      - Message:         '+3, including nesting penalty of 2, nesting level increased to 3'
+        FilePath:        'mbo/proto/matchers.cc'
+        FileOffset:      9213
+        Replacements:    []
+      - Message:         '+4, including nesting penalty of 3, nesting level increased to 4'
+        FilePath:        'mbo/proto/matchers.cc'
+        FileOffset:      9247
+        Replacements:    []
+      - Message:         'expanded from macro ''ABSL_CHECK'''
+        FilePath:        'external/abseil-cpp~/absl/log/absl_check.h'
+        FileOffset:      1825
+        Replacements:    []
+      - Message:         'expanded from macro ''ABSL_LOG_INTERNAL_CHECK_IMPL'''
+        FilePath:        'external/abseil-cpp~/absl/log/internal/check_impl.h'
+        FileOffset:      962
+        Replacements:    []
+      - Message:         'expanded from macro ''ABSL_LOG_INTERNAL_CONDITION_FATAL'''
+        FilePath:        'external/abseil-cpp~/absl/log/internal/conditions.h'
+        FileOffset:      9257
+        Replacements:    []
+      - Message:         expanded from here
+        FilePath:        ''
+        FileOffset:      0
+        Replacements:    []
+      - Message:         'expanded from macro ''ABSL_LOG_INTERNAL_STATELESS_CONDITION'''
+        FilePath:        'external/abseil-cpp~/absl/log/internal/conditions.h'
+        FileOffset:      2485
+        Replacements:    []
+      - Message:         '+5, including nesting penalty of 4, nesting level increased to 5'
+        FilePath:        'mbo/proto/matchers.cc'
+        FileOffset:      9247
+        Replacements:    []
+      - Message:         'expanded from macro ''ABSL_CHECK'''
+        FilePath:        'external/abseil-cpp~/absl/log/absl_check.h'
+        FileOffset:      1825
+        Replacements:    []
+      - Message:         'expanded from macro ''ABSL_LOG_INTERNAL_CHECK_IMPL'''
+        FilePath:        'external/abseil-cpp~/absl/log/internal/check_impl.h'
+        FileOffset:      962
+        Replacements:    []
+      - Message:         'expanded from macro ''ABSL_LOG_INTERNAL_CONDITION_FATAL'''
+        FilePath:        'external/abseil-cpp~/absl/log/internal/conditions.h'
+        FileOffset:      9257
+        Replacements:    []
+      - Message:         expanded from here
+        FilePath:        ''
+        FileOffset:      0
+        Replacements:    []
+      - Message:         'expanded from macro ''ABSL_LOG_INTERNAL_STATELESS_CONDITION'''
+        FilePath:        'external/abseil-cpp~/absl/log/internal/conditions.h'
+        FileOffset:      2677
+        Replacements:    []
+      - Message:         '+1'
+        FilePath:        'mbo/proto/matchers.cc'
+        FileOffset:      9247
+        Replacements:    []
+      - Message:         'expanded from macro ''ABSL_CHECK'''
+        FilePath:        'external/abseil-cpp~/absl/log/absl_check.h'
+        FileOffset:      1825
+        Replacements:    []
+      - Message:         'expanded from macro ''ABSL_LOG_INTERNAL_CHECK_IMPL'''
+        FilePath:        'external/abseil-cpp~/absl/log/internal/check_impl.h'
+        FileOffset:      1068
+        Replacements:    []
+      - Message:         'expanded from macro ''ABSL_PREDICT_FALSE'''
+        FilePath:        'external/abseil-cpp~/absl/base/optimization.h'
+        FileOffset:      7311
+        Replacements:    []
+      - Message:         '+1, nesting level increased to 3'
+        FilePath:        'mbo/proto/matchers.cc'
+        FileOffset:      9433
+        Replacements:    []
+      - Message:         '+4, including nesting penalty of 3, nesting level increased to 4'
+        FilePath:        'mbo/proto/matchers.cc'
+        FileOffset:      9551
+        Replacements:    []
+      - Message:         'expanded from macro ''ABSL_CHECK'''
+        FilePath:        'external/abseil-cpp~/absl/log/absl_check.h'
+        FileOffset:      1825
+        Replacements:    []
+      - Message:         'expanded from macro ''ABSL_LOG_INTERNAL_CHECK_IMPL'''
+        FilePath:        'external/abseil-cpp~/absl/log/internal/check_impl.h'
+        FileOffset:      962
+        Replacements:    []
+      - Message:         'expanded from macro ''ABSL_LOG_INTERNAL_CONDITION_FATAL'''
+        FilePath:        'external/abseil-cpp~/absl/log/internal/conditions.h'
+        FileOffset:      9257
+        Replacements:    []
+      - Message:         expanded from here
+        FilePath:        ''
+        FileOffset:      0
+        Replacements:    []
+      - Message:         'expanded from macro ''ABSL_LOG_INTERNAL_STATELESS_CONDITION'''
+        FilePath:        'external/abseil-cpp~/absl/log/internal/conditions.h'
+        FileOffset:      2485
+        Replacements:    []
+      - Message:         '+5, including nesting penalty of 4, nesting level increased to 5'
+        FilePath:        'mbo/proto/matchers.cc'
+        FileOffset:      9551
+        Replacements:    []
+      - Message:         'expanded from macro ''ABSL_CHECK'''
+        FilePath:        'external/abseil-cpp~/absl/log/absl_check.h'
+        FileOffset:      1825
+        Replacements:    []
+      - Message:         'expanded from macro ''ABSL_LOG_INTERNAL_CHECK_IMPL'''
+        FilePath:        'external/abseil-cpp~/absl/log/internal/check_impl.h'
+        FileOffset:      962
+        Replacements:    []
+      - Message:         'expanded from macro ''ABSL_LOG_INTERNAL_CONDITION_FATAL'''
+        FilePath:        'external/abseil-cpp~/absl/log/internal/conditions.h'
+        FileOffset:      9257
+        Replacements:    []
+      - Message:         expanded from here
+        FilePath:        ''
+        FileOffset:      0
+        Replacements:    []
+      - Message:         'expanded from macro ''ABSL_LOG_INTERNAL_STATELESS_CONDITION'''
+        FilePath:        'external/abseil-cpp~/absl/log/internal/conditions.h'
+        FileOffset:      2677
+        Replacements:    []
+      - Message:         '+1'
+        FilePath:        'mbo/proto/matchers.cc'
+        FileOffset:      9551
+        Replacements:    []
+      - Message:         'expanded from macro ''ABSL_CHECK'''
+        FilePath:        'external/abseil-cpp~/absl/log/absl_check.h'
+        FileOffset:      1825
+        Replacements:    []
+      - Message:         'expanded from macro ''ABSL_LOG_INTERNAL_CHECK_IMPL'''
+        FilePath:        'external/abseil-cpp~/absl/log/internal/check_impl.h'
+        FileOffset:      1068
+        Replacements:    []
+      - Message:         'expanded from macro ''ABSL_PREDICT_FALSE'''
+        FilePath:        'external/abseil-cpp~/absl/base/optimization.h'
+        FileOffset:      7311
+        Replacements:    []
+      - Message:         '+1, nesting level increased to 2'
+        FilePath:        'mbo/proto/matchers.cc'
+        FileOffset:      9747
+        Replacements:    []
+      - Message:         '+3, including nesting penalty of 2, nesting level increased to 3'
+        FilePath:        'mbo/proto/matchers.cc'
+        FileOffset:      9760
+        Replacements:    []
+      - Message:         'expanded from macro ''ABSL_LOG'''
+        FilePath:        'external/abseil-cpp~/absl/log/absl_log.h'
+        FileOffset:      1461
+        Replacements:    []
+      - Message:         'expanded from macro ''ABSL_LOG_INTERNAL_LOG_IMPL'''
+        FilePath:        'external/abseil-cpp~/absl/log/internal/log_impl.h'
+        FileOffset:      910
+        Replacements:    []
+      - Message:         expanded from here
+        FilePath:        ''
+        FileOffset:      0
+        Replacements:    []
+      - Message:         'expanded from macro ''ABSL_LOG_INTERNAL_CONDITION_FATAL'''
+        FilePath:        'external/abseil-cpp~/absl/log/internal/conditions.h'
+        FileOffset:      9257
+        Replacements:    []
+      - Message:         expanded from here
+        FilePath:        ''
+        FileOffset:      0
+        Replacements:    []
+      - Message:         'expanded from macro ''ABSL_LOG_INTERNAL_STATELESS_CONDITION'''
+        FilePath:        'external/abseil-cpp~/absl/log/internal/conditions.h'
+        FileOffset:      2485
+        Replacements:    []
+      - Message:         '+4, including nesting penalty of 3, nesting level increased to 4'
+        FilePath:        'mbo/proto/matchers.cc'
+        FileOffset:      9760
+        Replacements:    []
+      - Message:         'expanded from macro ''ABSL_LOG'''
+        FilePath:        'external/abseil-cpp~/absl/log/absl_log.h'
+        FileOffset:      1461
+        Replacements:    []
+      - Message:         'expanded from macro ''ABSL_LOG_INTERNAL_LOG_IMPL'''
+        FilePath:        'external/abseil-cpp~/absl/log/internal/log_impl.h'
+        FileOffset:      910
+        Replacements:    []
+      - Message:         expanded from here
+        FilePath:        ''
+        FileOffset:      0
+        Replacements:    []
+      - Message:         'expanded from macro ''ABSL_LOG_INTERNAL_CONDITION_FATAL'''
+        FilePath:        'external/abseil-cpp~/absl/log/internal/conditions.h'
+        FileOffset:      9257
+        Replacements:    []
+      - Message:         expanded from here
+        FilePath:        ''
+        FileOffset:      0
+        Replacements:    []
+      - Message:         'expanded from macro ''ABSL_LOG_INTERNAL_STATELESS_CONDITION'''
+        FilePath:        'external/abseil-cpp~/absl/log/internal/conditions.h'
+        FileOffset:      2677
+        Replacements:    []
+      - Message:         '+1, including nesting penalty of 0, nesting level increased to 1'
+        FilePath:        'mbo/proto/matchers.cc'
+        FileOffset:      9997
+        Replacements:    []
+      - Message:         'expanded from macro ''ABSL_CHECK'''
+        FilePath:        'external/abseil-cpp~/absl/log/absl_check.h'
+        FileOffset:      1825
+        Replacements:    []
+      - Message:         'expanded from macro ''ABSL_LOG_INTERNAL_CHECK_IMPL'''
+        FilePath:        'external/abseil-cpp~/absl/log/internal/check_impl.h'
+        FileOffset:      962
+        Replacements:    []
+      - Message:         'expanded from macro ''ABSL_LOG_INTERNAL_CONDITION_FATAL'''
+        FilePath:        'external/abseil-cpp~/absl/log/internal/conditions.h'
+        FileOffset:      9257
+        Replacements:    []
+      - Message:         expanded from here
+        FilePath:        ''
+        FileOffset:      0
+        Replacements:    []
+      - Message:         'expanded from macro ''ABSL_LOG_INTERNAL_STATELESS_CONDITION'''
+        FilePath:        'external/abseil-cpp~/absl/log/internal/conditions.h'
+        FileOffset:      2485
+        Replacements:    []
+      - Message:         '+2, including nesting penalty of 1, nesting level increased to 2'
+        FilePath:        'mbo/proto/matchers.cc'
+        FileOffset:      9997
+        Replacements:    []
+      - Message:         'expanded from macro ''ABSL_CHECK'''
+        FilePath:        'external/abseil-cpp~/absl/log/absl_check.h'
+        FileOffset:      1825
+        Replacements:    []
+      - Message:         'expanded from macro ''ABSL_LOG_INTERNAL_CHECK_IMPL'''
+        FilePath:        'external/abseil-cpp~/absl/log/internal/check_impl.h'
+        FileOffset:      962
+        Replacements:    []
+      - Message:         'expanded from macro ''ABSL_LOG_INTERNAL_CONDITION_FATAL'''
+        FilePath:        'external/abseil-cpp~/absl/log/internal/conditions.h'
+        FileOffset:      9257
+        Replacements:    []
+      - Message:         expanded from here
+        FilePath:        ''
+        FileOffset:      0
+        Replacements:    []
+      - Message:         'expanded from macro ''ABSL_LOG_INTERNAL_STATELESS_CONDITION'''
+        FilePath:        'external/abseil-cpp~/absl/log/internal/conditions.h'
+        FileOffset:      2677
+        Replacements:    []
+      - Message:         '+1'
+        FilePath:        'mbo/proto/matchers.cc'
+        FileOffset:      9997
+        Replacements:    []
+      - Message:         'expanded from macro ''ABSL_CHECK'''
+        FilePath:        'external/abseil-cpp~/absl/log/absl_check.h'
+        FileOffset:      1825
+        Replacements:    []
+      - Message:         'expanded from macro ''ABSL_LOG_INTERNAL_CHECK_IMPL'''
+        FilePath:        'external/abseil-cpp~/absl/log/internal/check_impl.h'
+        FileOffset:      1068
+        Replacements:    []
+      - Message:         'expanded from macro ''ABSL_PREDICT_FALSE'''
+        FilePath:        'external/abseil-cpp~/absl/base/optimization.h'
+        FileOffset:      7311
+        Replacements:    []
+      - Message:         '+1, including nesting penalty of 0, nesting level increased to 1'
+        FilePath:        'mbo/proto/matchers.cc'
+        FileOffset:      10032
+        Replacements:    []
+      - Message:         'expanded from macro ''ABSL_CHECK'''
+        FilePath:        'external/abseil-cpp~/absl/log/absl_check.h'
+        FileOffset:      1825
+        Replacements:    []
+      - Message:         'expanded from macro ''ABSL_LOG_INTERNAL_CHECK_IMPL'''
+        FilePath:        'external/abseil-cpp~/absl/log/internal/check_impl.h'
+        FileOffset:      962
+        Replacements:    []
+      - Message:         'expanded from macro ''ABSL_LOG_INTERNAL_CONDITION_FATAL'''
+        FilePath:        'external/abseil-cpp~/absl/log/internal/conditions.h'
+        FileOffset:      9257
+        Replacements:    []
+      - Message:         expanded from here
+        FilePath:        ''
+        FileOffset:      0
+        Replacements:    []
+      - Message:         'expanded from macro ''ABSL_LOG_INTERNAL_STATELESS_CONDITION'''
+        FilePath:        'external/abseil-cpp~/absl/log/internal/conditions.h'
+        FileOffset:      2485
+        Replacements:    []
+      - Message:         '+2, including nesting penalty of 1, nesting level increased to 2'
+        FilePath:        'mbo/proto/matchers.cc'
+        FileOffset:      10032
+        Replacements:    []
+      - Message:         'expanded from macro ''ABSL_CHECK'''
+        FilePath:        'external/abseil-cpp~/absl/log/absl_check.h'
+        FileOffset:      1825
+        Replacements:    []
+      - Message:         'expanded from macro ''ABSL_LOG_INTERNAL_CHECK_IMPL'''
+        FilePath:        'external/abseil-cpp~/absl/log/internal/check_impl.h'
+        FileOffset:      962
+        Replacements:    []
+      - Message:         'expanded from macro ''ABSL_LOG_INTERNAL_CONDITION_FATAL'''
+        FilePath:        'external/abseil-cpp~/absl/log/internal/conditions.h'
+        FileOffset:      9257
+        Replacements:    []
+      - Message:         expanded from here
+        FilePath:        ''
+        FileOffset:      0
+        Replacements:    []
+      - Message:         'expanded from macro ''ABSL_LOG_INTERNAL_STATELESS_CONDITION'''
+        FilePath:        'external/abseil-cpp~/absl/log/internal/conditions.h'
+        FileOffset:      2677
+        Replacements:    []
+      - Message:         '+1'
+        FilePath:        'mbo/proto/matchers.cc'
+        FileOffset:      10032
+        Replacements:    []
+      - Message:         'expanded from macro ''ABSL_CHECK'''
+        FilePath:        'external/abseil-cpp~/absl/log/absl_check.h'
+        FileOffset:      1825
+        Replacements:    []
+      - Message:         'expanded from macro ''ABSL_LOG_INTERNAL_CHECK_IMPL'''
+        FilePath:        'external/abseil-cpp~/absl/log/internal/check_impl.h'
+        FileOffset:      1068
+        Replacements:    []
+      - Message:         'expanded from macro ''ABSL_PREDICT_FALSE'''
+        FilePath:        'external/abseil-cpp~/absl/base/optimization.h'
+        FileOffset:      7311
+        Replacements:    []
+    Level:           Warning
+    BuildDirectory:  '/home/marcus/helly25/proto'
+  - DiagnosticName:  misc-use-internal-linkage
+    DiagnosticMessage:
+      Message:         'function ''SetIgnoredFieldPathsOrDie'' can be made static or moved into an anonymous namespace to enforce internal linkage'
+      FilePath:        'mbo/proto/matchers.cc'
+      FileOffset:      10321
+      Replacements:
+        - FilePath:        'mbo/proto/matchers.cc'
+          Offset:          10316
+          Length:          0
+          ReplacementText: 'static '
+    Level:           Warning
+    BuildDirectory:  '/home/marcus/helly25/proto'
+  - DiagnosticName:  cppcoreguidelines-owning-memory
+    DiagnosticMessage:
+      Message:         'initializing non-owner argument of type ''IgnoreCriteria *'' with a newly created ''gsl::owner<>'''
+      FilePath:        'mbo/proto/matchers.cc'
+      FileOffset:      10610
+      Replacements:    []
+      Ranges:
+        - FilePath:        'mbo/proto/matchers.cc'
+          FileOffset:      10610
+          Length:          77
+    Level:           Warning
+    BuildDirectory:  '/home/marcus/helly25/proto'
+  - DiagnosticName:  misc-use-internal-linkage
+    DiagnosticMessage:
+      Message:         'function ''ConfigureDifferencer'' can be made static or moved into an anonymous namespace to enforce internal linkage'
+      FilePath:        'mbo/proto/matchers.cc'
+      FileOffset:      10929
+      Replacements:
+        - FilePath:        'mbo/proto/matchers.cc'
+          Offset:          10924
+          Length:          0
+          ReplacementText: 'static '
+    Level:           Warning
+    BuildDirectory:  '/home/marcus/helly25/proto'
+  - DiagnosticName:  misc-include-cleaner
+    DiagnosticMessage:
+      Message:         'no header providing "google::protobuf::util::DefaultFieldComparator" is directly included'
+      FilePath:        'mbo/proto/matchers.cc'
+      FileOffset:      11024
+      Replacements:
+        - FilePath:        'mbo/proto/matchers.cc'
+          Offset:          1070
+          Length:          0
+          ReplacementText: "#include \"google/protobuf/util/field_comparator.h\"\n"
+    Level:           Warning
+    BuildDirectory:  '/home/marcus/helly25/proto'
+  - DiagnosticName:  readability-container-size-empty
+    DiagnosticMessage:
+      Message:         'the ''empty'' method should be used to check for emptiness instead of ''length'''
+      FilePath:        'mbo/proto/matchers.cc'
+      FileOffset:      14389
+      Replacements:
+        - FilePath:        'mbo/proto/matchers.cc'
+          Offset:          14389
+          Length:          17
+          ReplacementText: '!diff.empty()'
+    Notes:
+      - Message:         'method ''basic_string''::empty() defined here'
+        FilePath:        '/usr/bin/../lib/gcc/x86_64-linux-gnu/12/../../../../include/c++/12/bits/basic_string.h'
+        FileOffset:      37311
+        Replacements:    []
+    Level:           Warning
+    BuildDirectory:  '/home/marcus/helly25/proto'
+  - DiagnosticName:  misc-include-cleaner
+    DiagnosticMessage:
+      Message:         included header iostream is not used directly
+      FilePath:        'mbo/proto/matchers_test.cc'
+      FileOffset:      742
+      Replacements:
+        - FilePath:        'mbo/proto/matchers_test.cc'
+          Offset:          742
+          Length:          20
+          ReplacementText: ''
+    Level:           Warning
+    BuildDirectory:  '/home/marcus/helly25/proto'
+  - DiagnosticName:  misc-include-cleaner
+    DiagnosticMessage:
+      Message:         included header type_traits is not used directly
+      FilePath:        'mbo/proto/matchers_test.cc'
+      FileOffset:      780
+      Replacements:
+        - FilePath:        'mbo/proto/matchers_test.cc'
+          Offset:          780
+          Length:          23
+          ReplacementText: ''
+    Level:           Warning
+    BuildDirectory:  '/home/marcus/helly25/proto'
+  - DiagnosticName:  misc-unused-using-decls
+    DiagnosticMessage:
+      Message:         'using decl ''Each'' is unused'
+      FilePath:        'mbo/proto/matchers_test.cc'
+      FileOffset:      1107
+      Replacements:    []
+    Notes:
+      - Message:         remove the using
+        FilePath:        'mbo/proto/matchers_test.cc'
+        FileOffset:      1107
+        Replacements:
+          - FilePath:        'mbo/proto/matchers_test.cc'
+            Offset:          1090
+            Length:          23
+            ReplacementText: ''
+    Level:           Warning
+    BuildDirectory:  '/home/marcus/helly25/proto'
+  - DiagnosticName:  performance-unnecessary-value-param
+    DiagnosticMessage:
+      Message:         'the parameter ''matcher'' is copied for each invocation but only used as a const reference; consider making it a const reference'
+      FilePath:        'mbo/proto/matchers_test.cc'
+      FileOffset:      1320
+      Replacements:
+        - FilePath:        'mbo/proto/matchers_test.cc'
+          Offset:          1318
+          Length:          0
+          ReplacementText: 'const '
+        - FilePath:        'mbo/proto/matchers_test.cc'
+          Offset:          1319
+          Length:          0
+          ReplacementText: '&'
+    Level:           Warning
+    BuildDirectory:  '/home/marcus/helly25/proto'
+  - DiagnosticName:  misc-include-cleaner
+    DiagnosticMessage:
+      Message:         'no header providing "std::stringstream" is directly included'
+      FilePath:        'mbo/proto/matchers_test.cc'
+      FileOffset:      1354
+      Replacements:
+        - FilePath:        'mbo/proto/matchers_test.cc'
+          Offset:          762
+          Length:          0
+          ReplacementText: "#include <sstream>\n"
+    Level:           Warning
+    BuildDirectory:  '/home/marcus/helly25/proto'
+  - DiagnosticName:  readability-identifier-length
+    DiagnosticMessage:
+      Message:         'variable name ''ss'' is too short, expected at least 3 characters'
+      FilePath:        'mbo/proto/matchers_test.cc'
+      FileOffset:      1367
+      Replacements:    []
+    Level:           Warning
+    BuildDirectory:  '/home/marcus/helly25/proto'
+  - DiagnosticName:  misc-include-cleaner
+    DiagnosticMessage:
+      Message:         'no header providing "absl::Status" is directly included'
+      FilePath:        'mbo/proto/parse_text_proto.cc'
+      FileOffset:      1036
+      Replacements:
+        - FilePath:        'mbo/proto/parse_text_proto.cc'
+          Offset:          827
+          Length:          0
+          ReplacementText: "#include \"absl/status/status.h\"\n"
+    Level:           Warning
+    BuildDirectory:  '/home/marcus/helly25/proto'
+  - DiagnosticName:  misc-include-cleaner
+    DiagnosticMessage:
+      Message:         'no header providing "google::protobuf::Message" is directly included'
+      FilePath:        'mbo/proto/parse_text_proto.cc'
+      FileOffset:      1119
+      Replacements:
+        - FilePath:        'mbo/proto/parse_text_proto.cc'
+          Offset:          902
+          Length:          0
+          ReplacementText: "#include \"google/protobuf/message.h\"\n"
+    Level:           Warning
+    BuildDirectory:  '/home/marcus/helly25/proto'
+  - DiagnosticName:  misc-include-cleaner
+    DiagnosticMessage:
+      Message:         'no header providing "absl::OkStatus" is directly included'
+      FilePath:        'mbo/proto/parse_text_proto.cc'
+      FileOffset:      1408
+      Replacements:    []
+    Level:           Warning
+    BuildDirectory:  '/home/marcus/helly25/proto'
+  - DiagnosticName:  misc-include-cleaner
+    DiagnosticMessage:
+      Message:         'no header providing "absl::InvalidArgumentError" is directly included'
+      FilePath:        'mbo/proto/parse_text_proto.cc'
+      FileOffset:      1439
+      Replacements:    []
+    Level:           Warning
+    BuildDirectory:  '/home/marcus/helly25/proto'
+  - DiagnosticName:  misc-include-cleaner
+    DiagnosticMessage:
+      Message:         'no header providing "testing::ContainsRegex" is directly included'
+      FilePath:        'mbo/proto/parse_text_proto_test.cc'
+      FileOffset:      983
+      Replacements:
+        - FilePath:        'mbo/proto/parse_text_proto_test.cc'
+          Offset:          775
+          Length:          0
+          ReplacementText: "#include \"gtest/gtest.h\"\n"
+    Level:           Warning
+    BuildDirectory:  '/home/marcus/helly25/proto'
+  - DiagnosticName:  misc-include-cleaner
+    DiagnosticMessage:
+      Message:         'no header providing "testing::Test" is directly included'
+      FilePath:        'mbo/proto/parse_text_proto_test.cc'
+      FileOffset:      1044
+      Replacements:
+        - FilePath:        'mbo/proto/parse_text_proto_test.cc'
+          Offset:          749
+          Length:          0
+          ReplacementText: "#include <gtest/gtest.h>\n"
+    Level:           Warning
+    BuildDirectory:  '/home/marcus/helly25/proto'
+  - DiagnosticName:  misc-include-cleaner
+    DiagnosticMessage:
+      Message:         'no header providing "TEST_F" is directly included'
+      FilePath:        'mbo/proto/parse_text_proto_test.cc'
+      FileOffset:      1054
+      Replacements:    []
+    Level:           Warning
+    BuildDirectory:  '/home/marcus/helly25/proto'
+  - DiagnosticName:  misc-include-cleaner
+    DiagnosticMessage:
+      Message:         'no header providing "EXPECT_DEATH" is directly included'
+      FilePath:        'mbo/proto/parse_text_proto_test.cc'
+      FileOffset:      1305
+      Replacements:    []
+    Level:           Warning
+    BuildDirectory:  '/home/marcus/helly25/proto'
+  - DiagnosticName:  misc-const-correctness
+    DiagnosticMessage:
+      Message:         'variable ''msg'' of type ''SimpleMessage'' can be declared ''const'''
+      FilePath:        'mbo/proto/parse_text_proto_test.cc'
+      FileOffset:      2007
+      Replacements:    []
+    Level:           Warning
+    BuildDirectory:  '/home/marcus/helly25/proto'
+  - DiagnosticName:  misc-include-cleaner
+    DiagnosticMessage:
+      Message:         'no header providing "absl::StatusOr" is directly included'
+      FilePath:        'mbo/proto/parse_text_proto_test.cc'
+      FileOffset:      2615
+      Replacements:
+        - FilePath:        'mbo/proto/parse_text_proto_test.cc'
+          Offset:          750
+          Length:          0
+          ReplacementText: "#include \"absl/status/statusor.h\"\n"
+    Level:           Warning
+    BuildDirectory:  '/home/marcus/helly25/proto'
+  - DiagnosticName:  readability-identifier-naming
+    DiagnosticMessage:
+      Message:         'invalid case style for constexpr variable ''expected'''
+      FilePath:        'mbo/proto/parse_text_proto_test.cc'
+      FileOffset:      2717
+      Replacements:
+        - FilePath:        'mbo/proto/parse_text_proto_test.cc'
+          Offset:          2717
+          Length:          8
+          ReplacementText: kExpected
+        - FilePath:        'mbo/proto/parse_text_proto_test.cc'
+          Offset:          3221
+          Length:          8
+          ReplacementText: kExpected
+        - FilePath:        'mbo/proto/parse_text_proto_test.cc'
+          Offset:          3498
+          Length:          8
+          ReplacementText: kExpected
+    Level:           Warning
+    BuildDirectory:  '/home/marcus/helly25/proto'
+  - DiagnosticName:  misc-include-cleaner
+    DiagnosticMessage:
+      Message:         'no header providing "absl::StatusCode" is directly included'
+      FilePath:        'mbo/proto/parse_text_proto_test.cc'
+      FileOffset:      3135
+      Replacements:
+        - FilePath:        'mbo/proto/parse_text_proto_test.cc'
+          Offset:          750
+          Length:          0
+          ReplacementText: "#include \"absl/status/status.h\"\n"
+    Level:           Warning
+    BuildDirectory:  '/home/marcus/helly25/proto'
+  - DiagnosticName:  misc-include-cleaner
+    DiagnosticMessage:
+      Message:         'no header providing "absl::StrCat" is directly included'
+      FilePath:        'mbo/proto/parse_text_proto_test.cc'
+      FileOffset:      3312
+      Replacements:
+        - FilePath:        'mbo/proto/parse_text_proto_test.cc'
+          Offset:          750
+          Length:          0
+          ReplacementText: "#include \"absl/strings/str_cat.h\"\n"
+    Level:           Warning
+    BuildDirectory:  '/home/marcus/helly25/proto'
+  - DiagnosticName:  misc-include-cleaner
+    DiagnosticMessage:
+      Message:         included header vector is not used directly
+      FilePath:        'mbo/proto/silent_error_collector.cc'
+      FileOffset:      743
+      Replacements:
+        - FilePath:        'mbo/proto/silent_error_collector.cc'
+          Offset:          743
+          Length:          18
+          ReplacementText: ''
+    Level:           Warning
+    BuildDirectory:  '/home/marcus/helly25/proto'
+  - DiagnosticName:  misc-include-cleaner
+    DiagnosticMessage:
+      Message:         included header log_severity.h is not used directly
+      FilePath:        'mbo/proto/silent_error_collector.cc'
+      FileOffset:      762
+      Replacements:
+        - FilePath:        'mbo/proto/silent_error_collector.cc'
+          Offset:          762
+          Length:          36
+          ReplacementText: ''
+    Level:           Warning
+    BuildDirectory:  '/home/marcus/helly25/proto'
+  - DiagnosticName:  misc-include-cleaner
+    DiagnosticMessage:
+      Message:         included header tokenizer.h is not used directly
+      FilePath:        'mbo/proto/silent_error_collector.cc'
+      FileOffset:      904
+      Replacements:
+        - FilePath:        'mbo/proto/silent_error_collector.cc'
+          Offset:          904
+          Length:          42
+          ReplacementText: ''
+    Level:           Warning
+    BuildDirectory:  '/home/marcus/helly25/proto'
+  - DiagnosticName:  misc-include-cleaner
+    DiagnosticMessage:
+      Message:         'no header providing "std::string_view" is directly included'
+      FilePath:        'mbo/proto/silent_error_collector.cc'
+      FileOffset:      1191
+      Replacements:
+        - FilePath:        'mbo/proto/silent_error_collector.cc'
+          Offset:          743
+          Length:          0
+          ReplacementText: "#include <string_view>\n"
+    Level:           Warning
+    BuildDirectory:  '/home/marcus/helly25/proto'
+  - DiagnosticName:  misc-include-cleaner
+    DiagnosticMessage:
+      Message:         'no header providing "google::protobuf::io::ErrorCollector" is directly included'
+      FilePath:        'mbo/proto/silent_error_collector_test.cc'
+      FileOffset:      1193
+      Replacements:
+        - FilePath:        'mbo/proto/silent_error_collector_test.cc'
+          Offset:          805
+          Length:          0
+          ReplacementText: "#include \"google/protobuf/io/tokenizer.h\"\n"
+    Level:           Warning
+    BuildDirectory:  '/home/marcus/helly25/proto'
+  - DiagnosticName:  readability-identifier-length
+    DiagnosticMessage:
+      Message:         'parameter name ''ec'' is too short, expected at least 3 characters'
+      FilePath:        'mbo/proto/silent_error_collector_test.cc'
+      FileOffset:      1209
+      Replacements:    []
+    Level:           Warning
+    BuildDirectory:  '/home/marcus/helly25/proto'
+  - DiagnosticName:  misc-include-cleaner
+    DiagnosticMessage:
+      Message:         'no header providing "GOOGLE_PROTOBUF_VERSION" is directly included'
+      FilePath:        'mbo/proto/silent_error_collector_test.cc'
+      FileOffset:      1251
+      Replacements:
+        - FilePath:        'mbo/proto/silent_error_collector_test.cc'
+          Offset:          805
+          Length:          0
+          ReplacementText: "#include \"google/protobuf/stubs/common.h\"\n"
+    Level:           Warning
+    BuildDirectory:  '/home/marcus/helly25/proto'
+  - DiagnosticName:  readability-identifier-length
+    DiagnosticMessage:
+      Message:         'parameter name ''ec'' is too short, expected at least 3 characters'
+      FilePath:        'mbo/proto/silent_error_collector_test.cc'
+      FileOffset:      1561
+      Replacements:    []
+    Level:           Warning
+    BuildDirectory:  '/home/marcus/helly25/proto'
+  - DiagnosticName:  cppcoreguidelines-avoid-magic-numbers
+    DiagnosticMessage:
+      Message:         '25 is a magic number; consider replacing it with a named constant'
+      FilePath:        'mbo/proto/silent_error_collector_test.cc'
+      FileOffset:      1873
+      Replacements:    []
+    Level:           Warning
+    BuildDirectory:  '/home/marcus/helly25/proto'
+  - DiagnosticName:  cppcoreguidelines-avoid-magic-numbers
+    DiagnosticMessage:
+      Message:         '42 is a magic number; consider replacing it with a named constant'
+      FilePath:        'mbo/proto/silent_error_collector_test.cc'
+      FileOffset:      1877
+      Replacements:    []
+    Level:           Warning
+    BuildDirectory:  '/home/marcus/helly25/proto'
+  - DiagnosticName:  cppcoreguidelines-avoid-magic-numbers
+    DiagnosticMessage:
+      Message:         '33 is a magic number; consider replacing it with a named constant'
+      FilePath:        'mbo/proto/silent_error_collector_test.cc'
+      FileOffset:      1912
+      Replacements:    []
+    Level:           Warning
+    BuildDirectory:  '/home/marcus/helly25/proto'
+  - DiagnosticName:  cppcoreguidelines-avoid-magic-numbers
+    DiagnosticMessage:
+      Message:         '99 is a magic number; consider replacing it with a named constant'
+      FilePath:        'mbo/proto/silent_error_collector_test.cc'
+      FileOffset:      1916
+      Replacements:    []
+    Level:           Warning
+    BuildDirectory:  '/home/marcus/helly25/proto'
+  - DiagnosticName:  misc-include-cleaner
+    DiagnosticMessage:
+      Message:         'no header providing "absl::LogSeverity" is directly included'
+      FilePath:        'mbo/proto/silent_error_collector_test.cc'
+      FileOffset:      2194
+      Replacements:
+        - FilePath:        'mbo/proto/silent_error_collector_test.cc'
+          Offset:          744
+          Length:          0
+          ReplacementText: "#include \"absl/base/log_severity.h\"\n"
+    Level:           Warning
+    BuildDirectory:  '/home/marcus/helly25/proto'
+...

--- a/mbo/proto/matchers_test.cc
+++ b/mbo/proto/matchers_test.cc
@@ -15,9 +15,8 @@
 
 #include "mbo/proto/matchers.h"
 
-#include <iostream>
+#include <sstream>
 #include <string>
-#include <type_traits>
 
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
@@ -30,7 +29,6 @@ namespace {
 using ::mbo::proto::ParseTextProtoOrDie;
 using ::mbo::proto::tests::TestMessage;
 using ::mbo::proto::tests::TestMessage2;
-using ::testing::Each;
 using ::testing::EndsWith;
 using ::testing::HasSubstr;
 using ::testing::Matches;
@@ -38,10 +36,10 @@ using ::testing::Not;
 using ::testing::SafeMatcherCast;
 
 template<typename T, typename M>
-inline std::string GetExplanation(M matcher, const T& value) {
-  std::stringstream ss;
-  SafeMatcherCast<const T&>(matcher).ExplainMatchResultTo(value, &ss);
-  return ss.str();
+inline std::string GetExplanation(const M& matcher, const T& value) {
+  std::stringstream sss;
+  SafeMatcherCast<const T&>(matcher).ExplainMatchResultTo(value, &sss);
+  return sss.str();
 }
 
 TEST(Matchers, EqualsProto) {

--- a/mbo/proto/parse_text_proto.cc
+++ b/mbo/proto/parse_text_proto.cc
@@ -19,8 +19,10 @@
 #include <string>
 
 #include "absl/log/absl_log.h"
+#include "absl/status/status.h"
 #include "absl/strings/str_format.h"
 #include "absl/strings/string_view.h"
+#include "google/protobuf/message.h"
 #include "google/protobuf/text_format.h"
 #include "mbo/proto/silent_error_collector.h"
 

--- a/mbo/proto/parse_text_proto.h
+++ b/mbo/proto/parse_text_proto.h
@@ -69,6 +69,11 @@ class ParseTextProtoHelper final {
   bool parsed_{false};
 };
 
+[[deprecated("Use mbo::proto::ParseTextProtoOrDie(R\"pb(...)pb\")")]] inline proto_internal::ParseTextProtoHelper
+DeprecatedParseTextProtoOrDie(std::string_view text_proto, std::source_location loc = std::source_location::current()) {
+  return {text_proto, loc};
+}
+
 }  // namespace proto_internal
 
 // Parses the text in 'text_proto' into the proto message type requested as return type.
@@ -124,7 +129,14 @@ inline absl::StatusOr<T> ParseText(
 // techniques. Today, you really want to use the function. However, clang-tidy
 // still allows for special support, where the macro is known to take a
 // text-proto and thus clang-tidy applies automatic text-proto formatting.
-#define PARSE_TEXT_PROTO(text) ParseTextProtoOrDie(text)
+//
+// The correct replacement for the macro uses the 'pb' raw-string delimiter:
+// ```
+// ParseTextProtoOrDie(R"pb(...)pb")
+// ```
+//
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
+#define PARSE_TEXT_PROTO(text) proto_internal::DeprecatedParseTextProtoOrDie(text)
 #endif  // !PARSE_TEXT_PROTO
 
 #endif  // MBO_PROTO_PARSE_TEXT_PROTO_H_

--- a/mbo/proto/silent_error_collector.cc
+++ b/mbo/proto/silent_error_collector.cc
@@ -16,13 +16,11 @@
 #include "mbo/proto/silent_error_collector.h"
 
 #include <string>
-#include <vector>
+#include <string_view>
 
-#include "absl/base/log_severity.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_format.h"
 #include "absl/strings/str_join.h"
-#include "google/protobuf/io/tokenizer.h"
 
 namespace mbo::proto {
 


### PR DESCRIPTION
* Made macro `PARSE_TEXT_PROTO` issue a deprecation warning.
* Lots of cleanup.
* Raised minimum zlib version when built with proto version 27.0 for MacOS.