### PR TITLE
Update/simplify deps management

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
         os: [ubuntu-latest]
         bazel_mode: [bzlmod, workspace]
         compiler: [gcc]
-        gcc_version: [11, 12, 13]
+        gcc_version: [9, 10, 11, 12, 13]
         bazel_config: [cpp23, opt]
         exclude:
           - bazel_mode: workspace
@@ -51,6 +51,7 @@ jobs:
         llvm_version: [20.1.0, 19.1.6, 17.0.4]
         bazel_config: [asan, cpp23, opt, fastbuild]
         proto_version: ['30.0', '29.0', '28.0', '27.0']
+        module_default: ['proto30.0']
         exclude:
           - os: macos-latest
             llvm_version: 17.0.4
@@ -117,7 +118,8 @@ jobs:
       compiler: ${{ matrix.compiler }}
       llvm_version: "${{ matrix.llvm_version }}"
       bazel_config: ${{ matrix.bazel_config }}
-      proto_version: "${{ matrix.proto_version }}"
+      module_version: "proto${{ matrix.proto_version }}"
+      module_default: "${{ matrix.module_default }}"
 
   test-bcr:
     needs: [pre-commit, test-gcc]
@@ -126,7 +128,8 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
         bazel_mode: [bzlmod]
-        compiler: [clang]
+        compiler: [gcc]
+        gcc_version: [9]
         llvm_version: [19.1.6]
         bazel_config: [opt]
         module_version: [proto27.0]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,17 +20,13 @@ jobs:
         os: [ubuntu-latest]
         bazel_mode: [bzlmod, workspace]
         compiler: [gcc]
-        gcc_version: [10, 11, 12, 13]
+        gcc_version: [11, 12, 13]
         bazel_config: [cpp23, opt]
         exclude:
-          - bazel_mode: workspace
-            gcc_version: 10
           - bazel_mode: workspace
             gcc_version: 11
           - bazel_mode: workspace
             gcc_version: 13
-          - bazel_config: cpp23
-            gcc_version: 10
           - bazel_config: cpp23
             gcc_version: 11
           - bazel_config: cpp23
@@ -133,7 +129,7 @@ jobs:
         os: [ubuntu-latest, macos-latest]
         bazel_mode: [bzlmod]
         compiler: [gcc]
-        gcc_version: [10]
+        gcc_version: [11]
         llvm_version: [19.1.6]
         bazel_config: [opt]
         module_version: [proto27.0]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,17 +20,21 @@ jobs:
         os: [ubuntu-latest]
         bazel_mode: [bzlmod, workspace]
         compiler: [gcc]
-        gcc_version: [9, 10, 11, 12, 13]
+        gcc_version: [10, 11, 12, 13]
         bazel_config: [cpp23, opt]
         exclude:
+          - bazel_mode: workspace
+            gcc_version: 10
           - bazel_mode: workspace
             gcc_version: 11
           - bazel_mode: workspace
             gcc_version: 13
-          - gcc_version: 11
-            bazel_config: cpp23
-          - gcc_version: 12
-            bazel_config: cpp23
+          - bazel_config: cpp23
+            gcc_version: 10
+          - bazel_config: cpp23
+            gcc_version: 11
+          - bazel_config: cpp23
+            gcc_version: 12
 
     uses: ./.github/workflows/test.yml
     with:
@@ -129,7 +133,7 @@ jobs:
         os: [ubuntu-latest, macos-latest]
         bazel_mode: [bzlmod]
         compiler: [gcc]
-        gcc_version: [9]
+        gcc_version: [10]
         llvm_version: [19.1.6]
         bazel_config: [opt]
         module_version: [proto27.0]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -128,11 +128,16 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
         bazel_mode: [bzlmod]
-        compiler: [gcc]
+        compiler: [gcc, native]
         gcc_version: [11]
         llvm_version: [19.1.6]
         bazel_config: [opt]
         module_version: [proto27.0]
+        exclude:
+          - os: ubuntu-latest
+            compiler: native
+          - os: macos-latest
+            compiler: gcc
 
     uses: ./.github/workflows/test.yml
     with:
@@ -140,6 +145,7 @@ jobs:
       os: ${{ matrix.os }}
       bazel_mode: ${{ matrix.bazel_mode }}
       compiler: ${{ matrix.compiler }}
+      gcc_version: ${{ matrix.gcc_version }}
       llvm_version: ${{ matrix.llvm_version }}
       bazel_config: ${{ matrix.bazel_config }}
       module_version: ${{ matrix.module_version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,7 +66,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: bazelbuild/setup-bazelisk@v3
       - uses: egor-tensin/setup-gcc@v1
-        if: ${{inputs.compiler == 'gcc'}}
+        if: ${{inputs.compiler == 'gcc' && inputs.gcc_version != ''}}
         with:
           version: ${{inputs.gcc_version}}
           platform: ${{runner.arch}}
@@ -81,6 +81,10 @@ jobs:
               ${{env.CACHE_KEY_PREFIX}}
       - name: Build and Test
         run: |
+          if [ "${{inputs.compiler}}:${{inputs.gcc_version}}" == "gcc:" ]; then
+            echo "ERROR: When compiler=='gcc', then a valid 'compiler_version' must be given."
+            exit 1
+          fi
           declare -a BAZEL_INIT=()
           declare -a BAZEL_ARGS=()
           CACHE_ROOT=~/.cache
@@ -108,6 +112,10 @@ jobs:
           elif [ "${{inputs.compiler}}" == "gcc" ]; then
             export CC=/usr/local/bin/gcc
             export CXX=/usr/local/bin/g++
+          elif [ "${{inputs.compiler}}" == "native" ]; then
+            # Use whatever is found!
+            [ -n "${CC}" ] && [ -x "${CC}" ] && echo "CC: $(${CC} --version)"
+            [ -n "${CXX}" ] && [ -x "${CXX}" ] && echo "CXX: $(${CXX} --version)"
           else
             echo "ERROR: Matrix/Input var 'compiler' must be one of [clang, gcc]."
           fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,21 +42,21 @@ on:
         description: 'The GCC version to use. This is only for compiler=gcc and will be ignored otherwise (e.g. 11, 12, 13).'
         type: string
         default: ''
-      proto_version:
-        description: 'The Protobuf version to use, e.g. "30.0" (selects //bazelmod/MODULE.proto30.0.bazel).'
-        type: string
-        default: ''
       bazel_config:
         description: 'The way how Bazel should operate compilation and tests, one of (asan, fastbuild, opt).'
         type: string
         default: opt
       module_version:
-        description: 'Version string for the MODULE.$ver.bazel to be copied from the bzlmod directory.'
+        description: 'Version string for the "MODULE.${module_version}.bazel" to be copied from the bzlmod directory.'
+        type: string
+        default: ''
+      module_default:
+        description: 'If the "module_version" has this value, then no "MODULE.${module_version}.bazel" will be copied.'
         type: string
         default: ''
 
 env:
-  CACHE_KEY_PREFIX: ${{inputs.os}}-${{inputs.bazel_mode}}_${{inputs.compiler}}_${{inputs.llvm_version}}_${{inputs.gcc_version}}_${{inputs.proto_version}}_${{inputs.bazel_config}}_${{inputs.module_version}}
+  CACHE_KEY_PREFIX: ${{inputs.os}}-${{inputs.bazel_mode}}_${{inputs.compiler}}_${{inputs.llvm_version}}_${{inputs.gcc_version}}_${{inputs.bazel_config}}_${{inputs.module_version}}
 
 jobs:
   test:
@@ -111,11 +111,6 @@ jobs:
           else
             echo "ERROR: Matrix/Input var 'compiler' must be one of [clang, gcc]."
           fi
-          if [ -n "${{inputs.proto_version}}" ]; then
-            if [ "${{inputs.proto_version}}" != "30.0" ]; then
-              cp "bazelmod/MODULE.proto${{inputs.proto_version}}.bazel" MODULE.bazel
-            fi
-          fi
           if [ "${{inputs.bazel_config}}" == "asan" ]; then
             BAZEL_ARGS+=("-c" "dbg" "--config=asan")
           elif [ "${{inputs.bazel_config}}" == "cpp23" ]; then
@@ -128,9 +123,8 @@ jobs:
             echo "ERROR: Matrix/Input var 'bazel_config' must be one of [asan, cpp23, fastbuild, opt]."
           fi
           if [ -n "${{inputs.module_version}}" ]; then
-            cp "bazelmod/MODULE.${{inputs.module_version}}.bazel" MODULE.bazel
-            if [ -n "${{inputs.proto_version}}" ]; then
-              echo "ERROR: Matrix/Input var 'module_version' cannot be used together with var 'proto_version'."
+            if [ "${{inputs.module_version}}" != "${{inputs.module_default}}" ]; then
+              cp "bazelmod/MODULE.${{inputs.module_version}}.bazel" MODULE.bazel
             fi
           fi
           echo "BAZEL_INIT: ${BAZEL_INIT[@]}"

--- a/bazelmod/MODULE.proto28.0.bazel
+++ b/bazelmod/MODULE.proto28.0.bazel
@@ -24,7 +24,9 @@ module(
 # For local development we include LLVM and Hedron-Compile-Commands.
 # For bazelmod usage these have to be provided by the main module - if necessary.
 include("//bazelmod:hedron.MODULE.bazel")
+
 include("//bazelmod:llvm.MODULE.bazel")
+
 bazel_dep(name = "bazel_skylib", version = "1.7.1")
 bazel_dep(name = "rules_cc", version = "0.0.17")
 bazel_dep(name = "platforms", version = "0.0.10")

--- a/bazelmod/MODULE.proto29.0.bazel
+++ b/bazelmod/MODULE.proto29.0.bazel
@@ -24,7 +24,9 @@ module(
 # For local development we include LLVM and Hedron-Compile-Commands.
 # For bazelmod usage these have to be provided by the main module - if necessary.
 include("//bazelmod:hedron.MODULE.bazel")
+
 include("//bazelmod:llvm.MODULE.bazel")
+
 bazel_dep(name = "bazel_skylib", version = "1.7.1")
 bazel_dep(name = "rules_cc", version = "0.0.17")
 bazel_dep(name = "platforms", version = "0.0.10")

--- a/bazelmod/MODULE.proto29.1.bazel
+++ b/bazelmod/MODULE.proto29.1.bazel
@@ -24,7 +24,9 @@ module(
 # For local development we include LLVM and Hedron-Compile-Commands.
 # For bazelmod usage these have to be provided by the main module - if necessary.
 include("//bazelmod:hedron.MODULE.bazel")
+
 include("//bazelmod:llvm.MODULE.bazel")
+
 bazel_dep(name = "bazel_skylib", version = "1.7.1")
 bazel_dep(name = "rules_cc", version = "0.1.1")
 bazel_dep(name = "platforms", version = "0.0.11")

--- a/bazelmod/MODULE.proto30.0.bazel
+++ b/bazelmod/MODULE.proto30.0.bazel
@@ -24,7 +24,9 @@ module(
 # For local development we include LLVM and Hedron-Compile-Commands.
 # For bazelmod usage these have to be provided by the main module - if necessary.
 include("//bazelmod:hedron.MODULE.bazel")
+
 include("//bazelmod:llvm.MODULE.bazel")
+
 bazel_dep(name = "bazel_skylib", version = "1.7.1")
 bazel_dep(name = "rules_cc", version = "0.1.1")
 bazel_dep(name = "platforms", version = "0.0.11")


### PR DESCRIPTION
Update/simplify deps management: module_version and proto_version were effectively the same. Drop the latter and deal with it appropriately in main.yml. 

Switch BCR tasks to use GCC/11.

Older GCC versions:
- GCC  9: does not support --std=c++20, only --std=c++2a
- GCC 10: does not have std::source_location