### PR TITLE
More cache cleanup work.

### DIFF
--- a/.github/workflows/cache_cleanup.yml
+++ b/.github/workflows/cache_cleanup.yml
@@ -15,19 +15,28 @@ jobs:
         # that would mean that the `test` workflow triggered for the same state will not find any
         # caches. That is because the the `cache_cleanup` workflow is much faster and will most
         # likely finish during the initial `pre-commit` job of the `test` workflow.
+        # Not that last version for the head ref means last cache version per cache key prefix.
         run: |
           set -euo pipefail
           echo "Fetching list of cache keys for head ref '${HEAD_REF}' on PR '${PULL_REQUEST}'."
           if [ "${HEAD_REF}" == "refs/heads/main" ]; then
-            cacheKeysForPR=$(gh cache list --ref "${HEAD_REF}" --limit 100 --json id,createdAt --jq 'sort_by(.createdAt)|.[:-1]|.[].id')
+            cacheKeyPrefixList=$(gh cache list --ref refs/heads/main  --limit 250 --json id,key,ref,createdAt --jq "[map((.ref as \$ref|.key|split(\"-\")|index(\$ref) as \$idx|select(.|\$idx)|.[0:\$idx+1]|join(\"-\")) as \$prefix|.prefix=\$prefix)|.[]|.prefix]|sort|unique|.[]")
+            echo "Deleting all but last cache per key prefix for 'refs/heads/main'..."
+            for cacheKeyPrefix in ${cacheKeyPrefixList}; do
+              cacheKeyList=$(gh cache list --ref "${HEAD_REF}" --limit 250 --json id,key,createdAt --jq 'map(select(.key|startswith(\"${cacheKeyPrefix}\")))|sort_by(.createdAt)|.[:-1]|.[].id')
+              for cacheKey in ${cacheKeyList}; do
+                echo "Deleting cache: ${cacheKey}"
+                gh cache delete "${cacheKey}" || echo "Error deleting: ${cacheKey}."
+              done
+            done
           else
-            cacheKeysForPR=$(gh cache list --ref "${HEAD_REF}" --limit 100 --json id --jq '.[].id')
+            cacheKeyList=$(gh cache list --ref "${HEAD_REF}" --limit 250 --json id --jq '.[].id')
+            echo "Deleting all caches for '${HEAD_REF}'..."
+            for cacheKey in ${cacheKeyList}; do
+              echo "Deleting cache: ${cacheKey}"
+              gh cache delete "${cacheKey}" || echo "Error deleting: ${cacheKey}."
+            done
           fi
-          echo "Deleting caches..."
-          for cacheKey in ${cacheKeysForPR}; do
-            echo "Deleting cache: ${cacheKey}"
-            gh cache delete "${cacheKey}" || echo "Error deleting: ${cacheKey}."
-          done
           echo "Done"
         env:
           GH_TOKEN: ${{secrets.CACHE_ACCESS}}
@@ -39,8 +48,9 @@ jobs:
         run: |
           set -euo pipefail
           closedBeforeDate="$(date -Iminutes --date=-4hours)"
+          closedAfterDate="$(date -Iminutes --date=-14days)"
           echo "Fetching list of branch names for PRs closed before: ${closedBeforeDate}."
-          closedPrList=$(gh pr list -s closed --json headRefName,closedAt --jq "map(select(.closedAt < \"${closedBeforeDate}\"))|.[].headRefName")
+          closedPrList=$(gh pr list -s closed --json headRefName,closedAt --jq "map(select(.closedAt > \"${closedAfterDate}\" and .closedAt < \"${closedBeforeDate}\"))|.[].headRefName")
           for closedPr in ${closedPrList}; do
             echo "Deleting caches for '${closedPr}'..."
             cacheKeyList=$(gh cache list --ref "refs/heads/${closedPr}" --limit 250 --json id --jq '.[].id')

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,7 +56,7 @@ on:
         default: ''
 
 env:
-  CACHE_KEY_PREFIX: ${{inputs.os}}-${{inputs.bazel_mode}}_${{inputs.compiler}}_${{inputs.llvm_version}}_${{inputs.gcc_version}}_${{inputs.bazel_config}}_${{inputs.module_version}}
+  CACHE_KEY_PREFIX: ${{inputs.os}}-${{inputs.bazel_mode}}_${{inputs.compiler}}_${{inputs.compiler == 'clang' && inputs.llvm_version || ''}}_${{inputs.compiler == 'gcc' && inputs.gcc_version || ''}}_${{inputs.bazel_config}}_${{inputs.module_version}}
 
 jobs:
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -117,7 +117,7 @@ jobs:
             [ -n "${CC}" ] && [ -x "${CC}" ] && echo "CC: $(${CC} --version)"
             [ -n "${CXX}" ] && [ -x "${CXX}" ] && echo "CXX: $(${CXX} --version)"
           else
-            echo "ERROR: Matrix/Input var 'compiler' must be one of [clang, gcc]."
+            echo "ERROR: Matrix/Input var 'compiler' must be one of [clang, gcc, native]."
           fi
           if [ "${{inputs.bazel_config}}" == "asan" ]; then
             BAZEL_ARGS+=("-c" "dbg" "--config=asan")


### PR DESCRIPTION
* For refs/heads/main we must retain the last cache version per cache prefix.
* Increase limit of how many elements to query to 250.
* Limit the old branch cleanup to -14 days.