### PR TITLE
Version 1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-# 1.0.0+bcr1
+# 1.0.1
+
+* Repackage 1.0.0.
+
+# 1.0.0
 
 * Changed to empty root BUILD file for release packages.
 * Cut and packaged version 1.0.0 (no functionality changes compared to 0.6.4).

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -18,7 +18,7 @@
 # Due to flag and test references to the repo name we use the old name for now.
 module(
     name = "helly25_proto",
-    version = "1.0.0+bcr1",
+    version = "1.0.1",
 )
 
 # For local development we include LLVM and Hedron-Compile-Commands.


### PR DESCRIPTION
* Changed to empty root BUILD file for release packages.
* Cut and packaged version 1.0.0 (no functionality changes compared to 0.6.4).
* Repackage 1.0.0.