### PR TITLE
ci(bcr): test on macos_arm64 instead of Intel macos

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -4,7 +4,7 @@ matrix:
   - 8.x
   platform:
   - ubuntu2404
-  - macos
+  - macos_arm64
 tasks:
   verify_targets:
     name: Verify build targets


### PR DESCRIPTION
The BCR `macos` platform runs on Intel x86_64, which we no longer test. This switches the presubmit matrix to `macos_arm64` (Apple Silicon).

- platform: `macos` → `macos_arm64`

_Note: the bazel version matrix is intentionally left unchanged here (`7.x, 8.x`); the 8.x/9.x rework tied to the protobuf 34.1 bump is handled by the in-flight migration._