### PR TITLE
Bump version from 1.2.1 to 1.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # 1.2.2
 
+* Force a Bazel-9-compatible `rules_android` (0.7.2) via MVS, so downstream consumers (and the BCR presubmit) don't hit protobuf's transitive `rules_android` 0.6.4 failing to load on Bazel 9.
+
 # 1.2.1
 
 * Require Bazel 8 or newer and bzlmod; dropped WORKSPACE support.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# 1.2.2
+
 # 1.2.1
 
 * Require Bazel 8 or newer and bzlmod; dropped WORKSPACE support.

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -54,3 +54,13 @@ bazel_dep(name = "protobuf", version = "34.1", repo_name = "com_google_protobuf"
 # its own deps all sit below our pins, so it adds nothing else. Drop once
 # protobuf's transitive rules_go is new enough on its own.
 bazel_dep(name = "rules_go", version = "0.61.0")
+
+# Same class of fix for the other Bazel-9-incompatible toolchain protobuf pulls:
+# rules_android. Its `@androidsdk//:all` toolchain registration makes Bazel load
+# rules_android's `attrs.bzl` during C++ toolchain resolution on any host with an
+# Android SDK (CI runners, the BCR presubmit). The pinned rules_android (0.6.4)
+# imports the legacy `CcInfo` removed in rules_cc 0.2.x, so it fails to compile on
+# Bazel 9. Force a current rules_android via MVS. (`.bazelrc` blanks ANDROID_HOME
+# for our own builds; this shim is what fixes downstream consumers, which never
+# see our `.bazelrc` -- e.g. the BCR presubmit.)
+bazel_dep(name = "rules_android", version = "0.7.2")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -19,7 +19,7 @@
 # code depends on it anymore. Slated for removal in a future breaking release.
 module(
     name = "helly25_proto",
-    version = "1.2.1",
+    version = "1.2.2",
     repo_name = "com_helly25_proto",
 )
 


### PR DESCRIPTION
Automated version bump from 1.2.1 to 1.2.2 created by tools/trigger_release.sh. Please review and merge.